### PR TITLE
Add project CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+#####################################################
+#
+# List of approvers for this repository
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+* @open-telemetry/go-instrumentation-approvers
+
+CODEOWNERS @open-telemetry/go-instrumentaiton-maintainers


### PR DESCRIPTION
Define the CODEOWNERS file as owned by the project maintainers and all else owned by the approvers. This define the required reviews for modification of the owned files.