### PR TITLE
Replace bpf_ktime_get_boot_ns calls

### DIFF
--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf/probe.bpf.c
@@ -52,7 +52,7 @@ SEC("uprobe/GorillaMux_ServeHTTP")
 int uprobe_GorillaMux_ServeHTTP(struct pt_regs *ctx) {
     u64 request_pos = 4;
     struct http_request_t httpReq = {};
-    httpReq.start_time = bpf_ktime_get_boot_ns();
+    httpReq.start_time = bpf_ktime_get_ns();
 
     // Get request struct
     void* req_ptr = get_argument(ctx, request_pos);
@@ -98,7 +98,7 @@ int uprobe_GorillaMux_ServeHTTP_Returns(struct pt_regs *ctx) {
     void* httpReq_ptr = bpf_map_lookup_elem(&context_to_http_events, &ctx_iface);
     struct http_request_t httpReq = {};
     bpf_probe_read(&httpReq, sizeof(httpReq), httpReq_ptr);
-    httpReq.end_time = bpf_ktime_get_boot_ns();
+    httpReq.end_time = bpf_ktime_get_ns();
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
     bpf_map_delete_elem(&context_to_http_events, &ctx_iface);
     bpf_map_delete_elem(&spans_in_progress, &ctx_iface);

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf/probe.bpf.c
@@ -81,7 +81,7 @@ int uprobe_ClientConn_Invoke(struct pt_regs *ctx)
     u64 method_len_pos = 5;
 
     struct grpc_request_t grpcReq = {};
-    grpcReq.start_time = bpf_ktime_get_boot_ns();
+    grpcReq.start_time = bpf_ktime_get_ns();
 
     // Read Method
     void *method_ptr = get_argument(ctx, method_ptr_pos);
@@ -115,7 +115,7 @@ int uprobe_ClientConn_Invoke_Returns(struct pt_regs *ctx)
     struct grpc_request_t grpcReq = {};
     bpf_probe_read(&grpcReq, sizeof(grpcReq), grpcReq_ptr);
 
-    grpcReq.end_time = bpf_ktime_get_boot_ns();
+    grpcReq.end_time = bpf_ktime_get_ns();
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &grpcReq, sizeof(grpcReq));
     bpf_map_delete_elem(&context_to_grpc_events, &context_ptr);
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
@@ -95,7 +95,7 @@ int uprobe_server_handleStream(struct pt_regs *ctx)
     }
 
     // Set attributes
-    grpcReq.start_time = bpf_ktime_get_boot_ns();
+    grpcReq.start_time = bpf_ktime_get_ns();
     void *method_ptr = 0;
     bpf_probe_read(&method_ptr, sizeof(method_ptr), (void *)(stream_ptr + stream_method_ptr_pos));
     u64 method_len = 0;
@@ -137,7 +137,7 @@ int uprobe_server_handleStream_ByRegisters(struct pt_regs *ctx)
     }
 
     // Set attributes
-    grpcReq.start_time = bpf_ktime_get_boot_ns();
+    grpcReq.start_time = bpf_ktime_get_ns();
     void *method_ptr = 0;
     bpf_probe_read(&method_ptr, sizeof(method_ptr), (void *)(stream_ptr + stream_method_ptr_pos));
     u64 method_len = 0;
@@ -170,7 +170,7 @@ int uprobe_server_handleStream_Returns(struct pt_regs *ctx)
     struct grpc_request_t grpcReq = {};
     bpf_probe_read(&grpcReq, sizeof(grpcReq), grpcReq_ptr);
 
-    grpcReq.end_time = bpf_ktime_get_boot_ns();
+    grpcReq.end_time = bpf_ktime_get_ns();
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &grpcReq, sizeof(grpcReq));
     bpf_map_delete_elem(&context_to_grpc_events, &ctx_instance);
     bpf_map_delete_elem(&spans_in_progress, &ctx_instance);

--- a/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
@@ -56,7 +56,7 @@ int uprobe_ServerMux_ServeHTTP(struct pt_regs *ctx)
 {
     u64 request_pos = 4;
     struct http_request_t httpReq = {};
-    httpReq.start_time = bpf_ktime_get_boot_ns();
+    httpReq.start_time = bpf_ktime_get_ns();
 
     // Get request struct
     void *req_ptr = get_argument(ctx, request_pos);
@@ -103,7 +103,7 @@ int uprobe_ServerMux_ServeHTTP_Returns(struct pt_regs *ctx)
     void *httpReq_ptr = bpf_map_lookup_elem(&context_to_http_events, &ctx_iface);
     struct http_request_t httpReq = {};
     bpf_probe_read(&httpReq, sizeof(httpReq), httpReq_ptr);
-    httpReq.end_time = bpf_ktime_get_boot_ns();
+    httpReq.end_time = bpf_ktime_get_ns();
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
     bpf_map_delete_elem(&context_to_http_events, &ctx_iface);
     bpf_map_delete_elem(&spans_in_progress, &ctx_iface);


### PR DESCRIPTION
As discussed in the last SIG meeting, using `bpf_ktime_get_boot_ns()` requires a pretty new version of the kernel.
This PR replaces any invocation of `bpf_ktime_get_boot_ns()` with `bpf_ktime_get_ns()` that exists in old kernel versions.