### PR TITLE
Add automatic offsets generator CI job

### DIFF
--- a/.github/workflows/offsets.yml
+++ b/.github/workflows/offsets.yml
@@ -1,0 +1,29 @@
+name: Automatic Offset Generation
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  updateOffsets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+
+      - name: Update offsets
+        run: make offsets
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Update generated offsets
+          branch: automated/generated-offsets
+          delete-branch: true
+          title: '[auto] Update generated offsets'
+          body: 'This is an automated PR to update the generated Go field offsets.'

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ build: generate
 .PHONY: docker-build
 docker-build:
 	docker build -t $(IMG) .
+
+.PHONY: offsets
+offsets:
+	cd offsets-tracker; go run main.go

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ docker-build:
 
 .PHONY: offsets
 offsets:
-	cd offsets-tracker; go run main.go
+	cd offsets-tracker; OFFSETS_OUTPUT_FILE="../pkg/inject/offset_results.json" go run main.go

--- a/offsets-tracker/go.mod
+++ b/offsets-tracker/go.mod
@@ -2,4 +2,4 @@ module github.com/keyval-dev/offsets-tracker
 
 go 1.17
 
-require github.com/hashicorp/go-version v1.4.0 // indirect
+require github.com/hashicorp/go-version v1.4.0

--- a/offsets-tracker/main.go
+++ b/offsets-tracker/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/hashicorp/go-version"
 	"github.com/keyval-dev/offsets-tracker/binary"
 	"github.com/keyval-dev/offsets-tracker/target"
 	"github.com/keyval-dev/offsets-tracker/writer"
-	"log"
 )
 
 const (
@@ -15,7 +17,11 @@ const (
 )
 
 func main() {
-	outputFile := flag.String("output", defaultOutputFile, "output file")
+	outputFilename := defaultOutputFile
+	if len(os.Getenv("OFFSETS_OUTPUT_FILE")) > 0 {
+		outputFilename = os.Getenv("OFFSETS_OUTPUT_FILE")
+	}
+	outputFile := flag.String("output", outputFilename, "output file")
 	flag.Parse()
 
 	minimunGoVersion, err := version.NewConstraint(">= 1.12")


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/25

This adds:
* `make offsets` to generate offsets
* `OFFSETS_OUTPUT_FILE` env var to the offsets generator to overwrite the default
* CI job that will run `make offsets` every sunday and open a PR if changes are found
    * sample PR https://github.com/damemi/opentelemetry-go-instrumentation/pull/9
    * sample job run https://github.com/damemi/opentelemetry-go-instrumentation/actions/runs/4235154866