### PR TITLE
[admin] Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build-and-push-image:
+    env:
+      IMAGE_NAME: autoinstrumentation-go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            otel/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Set up QEMU


### PR DESCRIPTION
Adds a new `release.yaml` workflow that is triggered on the push of new tags.  Shamelessly stolen and modified from https://github.com/keyval-dev/opentelemetry-go-instrumentation/blob/master/.github/workflows/release.yml.

I am woefully underqualified to name this image, but I went with `otel/autoinstrumentation-go` for this PR.  I reviewed the [existing otel images on DockerHub](https://hub.docker.com/u/otel), the [images published by the operator repo](https://github.com/orgs/open-telemetry/packages?repo_name=opentelemetry-operator), and the the java agent .jar name (`opentelemetry-javaagent.jar`).  Someone with authority should name this image because we don't want to rename it in the future.

Tested via my fork.  Published images can be found here:
- https://hub.docker.com/r/thelmuth34/autoinstrumentation-go/tags
- https://github.com/TylerHelmuth/opentelemetry-go-instrumentation/pkgs/container/opentelemetry-go-instrumentation%2Fautoinstrumentation-go

Closes https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/31.