### PR TITLE
Add fixture-based e2e tests with sample apps

### DIFF
--- a/.github/workflows/e2e/k8s/collector-helm-values.yml
+++ b/.github/workflows/e2e/k8s/collector-helm-values.yml
@@ -1,0 +1,43 @@
+mode: "statefulset"
+
+config:
+  exporters:
+    logging: {}
+    file/trace:
+      path: /tmp/trace.json
+      rotation:
+
+  service:
+    telemetry:
+      logs:
+        level: "debug"
+    pipelines:
+      traces:
+        receivers:
+          - otlp
+        exporters:
+          - file/trace
+          - logging
+      
+          
+image:
+  repository: otel/opentelemetry-collector-contrib
+  tag: "latest"
+
+command:
+  name: otelcol-contrib
+
+extraVolumes:
+- name: filevolume
+  emptyDir: {}
+extraVolumeMounts: 
+- mountPath: /tmp
+  name: filevolume
+
+extraContainers: 
+- name: filecp
+  image: busybox
+  command: ["sh", "-c", "sleep 36000"]   
+  volumeMounts:
+  - name: filevolume
+    mountPath: /tmp

--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sample-job
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        workload: job
+      labels:
+        app: sample
+    spec:
+      shareProcessNamespace: true
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      initContainers:
+      - name: copy-launcher
+        image: kv-launcher
+        imagePullPolicy: IfNotPresent
+        command:
+          - cp
+          - -a
+          - /kv-launcher/.
+          - /launcher/
+        volumeMounts:
+          - name: launcherdir
+            mountPath: /launcher
+
+      containers:
+      - name: sample-app
+        image: sample-app
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
+        # send SIGTERM to otel-go-instrumentation once the sample app has generated data so the job completes.
+        args: ["/launcher/launch /sample-app/main && kill -TERM $(pidof otel-go-instrumentation)"]
+        volumeMounts:
+        - mountPath: /launcher
+          name: launcherdir
+
+      - name: auto-instrumentation
+        image: otel-go-instrumentation
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: OTEL_TARGET_EXE
+          value: /sample-app/main
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "test-opentelemetry-collector:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "sample-app"
+        resources: {}
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - SYS_PTRACE
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/kernel/debug
+          name: kernel-debug
+
+      volumes:
+      - name: launcherdir
+        emptyDir: {}
+      - name: kernel-debug
+        hostPath:
+          path: /sys/kernel/debug

--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -50,6 +50,8 @@ spec:
           value: "test-opentelemetry-collector:4317"
         - name: OTEL_SERVICE_NAME
           value: "sample-app"
+        - name: OTEL_PROPAGATORS
+          value: "tracecontext,baggage"
         resources: {}
         securityContext:
           runAsUser: 0

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -1,0 +1,83 @@
+name: e2e-tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+
+jobs:
+  kubernetes-test:
+    strategy: 
+      matrix:
+        k8s-version: ["v1.26.0"]
+        library: ["gorillamux", "nethttp"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19   
+      - name: Build auto-instrumentation
+        timeout-minutes: 5
+        run: |
+          IMG=otel-go-instrumentation:latest make docker-build
+      - name: Build launcher #TODO: Remove launcher steps once pr/40 merges
+        run: |
+          git clone https://github.com/keyval-dev/launcher.git
+          cd launcher
+          docker build -t kv-launcher:latest .
+      - name: Build sample app
+        run: |
+          cd test/e2e/${{ matrix.library }}
+          docker build -t sample-app:latest .
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.9.0
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.5.0
+        with:
+          node_image: kindest/node:${{ matrix.k8s-version }}
+          kubectl_version: ${{ matrix.k8s-version }}
+      - name: Check kind
+        run: |
+          kubectl cluster-info --context kind-chart-testing
+          kubectl get node
+          docker ps -a --filter label=io.x-k8s.kind.cluster=chart-testing
+      - name: Kind load images
+        run: |
+          kind load docker-image otel-go-instrumentation --name chart-testing
+          kind load docker-image kv-launcher --name chart-testing
+          kind load docker-image sample-app --name chart-testing
+      - name: Add Dependencies
+        shell: bash
+        run: |
+            helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+      - uses: actions/checkout@v3
+        with:
+          repository: 'open-telemetry/opentelemetry-helm-charts'
+          path: opentelemetry-helm-charts
+      - name: Helm install collector
+        run: helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
+      - name: check collector status
+        run: |
+          kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
+      - name: start sample job
+        run: |
+          kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
+      - name: check job status
+        run: |
+          kubectl wait --for=condition=Complete --timeout=60s job/sample-job
+      - name: copy telemetry trace output
+        run: |
+          kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json.tmp
+          jq --sort-keys 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/${{ matrix.library }}/traces.json.tmp > ./test/e2e/${{ matrix.library }}/traces.json
+          rm ./test/e2e/${{ matrix.library }}/traces.json.tmp
+      - name: verify output
+        run: |
+          git diff --exit-code || (echo 'output fixture diff detected')

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -80,4 +80,4 @@ jobs:
           rm ./test/e2e/${{ matrix.library }}/traces.json.tmp
       - name: verify output
         run: |
-          git diff --exit-code || (echo 'output fixture diff detected')
+          git diff --exit-code || (echo 'output fixture diff detected' && exit 1)

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -76,7 +76,7 @@ jobs:
       - name: copy telemetry trace output
         run: |
           kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json.tmp
-          jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/${{ matrix.library }}/traces.json.tmp | jq --sort-keys . > ./test/e2e/${{ matrix.library }}/traces.json
+          jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano) | .resourceSpans[].scopeSpans[].spans[].spanId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans[].spans[].traceId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans|=sort_by(.scope.name)' ./test/e2e/${{ matrix.library }}/traces.json.tmp | jq --sort-keys . > ./test/e2e/${{ matrix.library }}/traces.json
           rm ./test/e2e/${{ matrix.library }}/traces.json.tmp
       - name: verify output
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19   
+          go-version: "1.20"
       - name: Build auto-instrumentation
         timeout-minutes: 5
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -76,7 +76,7 @@ jobs:
       - name: copy telemetry trace output
         run: |
           kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json.tmp
-          jq --sort-keys 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/${{ matrix.library }}/traces.json.tmp > ./test/e2e/${{ matrix.library }}/traces.json
+          jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/${{ matrix.library }}/traces.json.tmp | jq --sort-keys . > ./test/e2e/${{ matrix.library }}/traces.json
           rm ./test/e2e/${{ matrix.library }}/traces.json.tmp
       - name: verify output
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 # GoLand IDEA
 /.idea/
 *.iml
+
+otel-go-instrumentation
+launcher/
+opentelemetry-helm-charts/

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,6 @@ fixtures/%:
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job
 	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces.json.tmp
-	jq --sort-keys 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/$(LIBRARY)/traces.json.tmp > ./test/e2e/$(LIBRARY)/traces.json
+	jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/$(LIBRARY)/traces.json.tmp | jq --sort-keys . > ./test/e2e/$(LIBRARY)/traces.json
 	rm ./test/e2e/$(LIBRARY)/traces.json.tmp
 	kind delete cluster

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,6 @@ fixtures/%:
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job
 	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces.json.tmp
-	jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano)' ./test/e2e/$(LIBRARY)/traces.json.tmp | jq --sort-keys . > ./test/e2e/$(LIBRARY)/traces.json
+	jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano) | .resourceSpans[].scopeSpans[].spans[].spanId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans[].spans[].traceId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans|=sort_by(.scope.name)' ./test/e2e/$(LIBRARY)/traces.json.tmp | jq --sort-keys . > ./test/e2e/$(LIBRARY)/traces.json
 	rm ./test/e2e/$(LIBRARY)/traces.json.tmp
 	kind delete cluster

--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,11 @@ verify-licenses: | $(GOLICENSES)
       exit 1; \
     fi; \
 
-.PHONY: fixture-gorillamux
-fixture-gorillamux:
-	LIBRARY=gorillamux $(MAKE) fixture
-
-.PHONY: fixture-nethttp
-fixture-nethttp:
-	LIBRARY=nethttp $(MAKE) fixture
-
-.PHONY: fixture
-fixture:
+.PHONY: fixture-nethttp fixture-gorillamux
+fixture-nethttp: fixtures/nethttp
+fixture-gorillamux: fixtures/gorillamux
+fixture/%: LIBRARY=$*
+fixture/%:
 	IMG=otel-go-instrumentation $(MAKE) docker-build
 	if [ ! -d "launcher" ]; then \
 		git clone https://github.com/keyval-dev/launcher.git; \

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ verify-licenses: | $(GOLICENSES)
 .PHONY: fixture-nethttp fixture-gorillamux
 fixture-nethttp: fixtures/nethttp
 fixture-gorillamux: fixtures/gorillamux
-fixture/%: LIBRARY=$*
-fixture/%:
+fixtures/%: LIBRARY=$*
+fixtures/%:
 	IMG=otel-go-instrumentation $(MAKE) docker-build
 	if [ ! -d "launcher" ]; then \
 		git clone https://github.com/keyval-dev/launcher.git; \
@@ -74,7 +74,7 @@ fixture/%:
 	kind load docker-image otel-go-instrumentation sample-app kv-launcher
 	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 	if [ ! -d "opentelemetry-helm-charts" ]; then \
-		git clone https://open-telemetry/opentelemetry-helm-charts; \
+		git clone https://github.com/open-telemetry/opentelemetry-helm-charts.git; \
 	fi
 	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0

--- a/pkg/inject/offset_results.json
+++ b/pkg/inject/offset_results.json
@@ -5,1409 +5,23 @@
       "data_members": [
         {
           "struct": "net/http.Request",
-          "field_name": "Method",
-          "offsets": [
-            {
-              "offset": 0,
-              "version": "1.20"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.19.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.19"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.18.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.18"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.17.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.17"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.16.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.16"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.15.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.14.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.13.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.17"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.16"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.15"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.14"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.13"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.12"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.11"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.10"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.9"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.8"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.7"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.6"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.5"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.4"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.3"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.2"
-            },
-            {
-              "offset": 0,
-              "version": "1.12.1"
-            },
-            {
-              "offset": 0,
-              "version": "1.12"
-            }
-          ]
-        },
-        {
-          "struct": "net/http.Request",
-          "field_name": "URL",
-          "offsets": [
-            {
-              "offset": 16,
-              "version": "1.20"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.19.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.19"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.18.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.18"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.17.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.17"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.16.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.16"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.15.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.14.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.13.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.17"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.16"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.15"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.14"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.13"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.12"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.11"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.10"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.9"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.8"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.7"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.6"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.5"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.4"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.3"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.2"
-            },
-            {
-              "offset": 16,
-              "version": "1.12.1"
-            },
-            {
-              "offset": 16,
-              "version": "1.12"
-            }
-          ]
-        },
-        {
-          "struct": "net/http.Request",
-          "field_name": "RemoteAddr",
-          "offsets": [
-            {
-              "offset": 176,
-              "version": "1.20"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.19.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.19"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.18.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.18"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.17.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.17"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.16.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.16"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.15.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.14.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.13.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.17"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.16"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.15"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.14"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.13"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.12"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.11"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.10"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.9"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.8"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.7"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.6"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.5"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.4"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.3"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.2"
-            },
-            {
-              "offset": 176,
-              "version": "1.12.1"
-            },
-            {
-              "offset": 176,
-              "version": "1.12"
-            }
-          ]
-        },
-        {
-          "struct": "net/http.Request",
           "field_name": "ctx",
           "offsets": [
             {
               "offset": 232,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 232,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 232,
               "version": "1.20"
+            },
+            {
+              "offset": 232,
+              "version": "1.19.7"
             },
             {
               "offset": 232,
@@ -1873,7 +487,19 @@
           "offsets": [
             {
               "offset": 56,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 56,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 56,
               "version": "1.20"
+            },
+            {
+              "offset": 56,
+              "version": "1.19.7"
             },
             {
               "offset": 56,
@@ -2339,7 +965,19 @@
           "offsets": [
             {
               "offset": 152,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 152,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 152,
               "version": "1.20"
+            },
+            {
+              "offset": 152,
+              "version": "1.19.7"
             },
             {
               "offset": 152,
@@ -2795,6 +1433,1440 @@
             },
             {
               "offset": 152,
+              "version": "1.12"
+            }
+          ]
+        },
+        {
+          "struct": "net/http.Request",
+          "field_name": "Method",
+          "offsets": [
+            {
+              "offset": 0,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.20"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.19.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.19"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.18.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.18"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.17.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.17"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.16.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.16"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.15.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.14.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.13.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.17"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.16"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.15"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.14"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.13"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.12"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.11"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.10"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.9"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.8"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.7"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.6"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.5"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.4"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.3"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.2"
+            },
+            {
+              "offset": 0,
+              "version": "1.12.1"
+            },
+            {
+              "offset": 0,
+              "version": "1.12"
+            }
+          ]
+        },
+        {
+          "struct": "net/http.Request",
+          "field_name": "URL",
+          "offsets": [
+            {
+              "offset": 16,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.20"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.19.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.19"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.18.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.18"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.17.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.17"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.16.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.16"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.15.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.14.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.13.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.17"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.16"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.15"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.14"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.13"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.12"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.11"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.10"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.9"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.8"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.7"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.6"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.5"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.4"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.3"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.2"
+            },
+            {
+              "offset": 16,
+              "version": "1.12.1"
+            },
+            {
+              "offset": 16,
+              "version": "1.12"
+            }
+          ]
+        },
+        {
+          "struct": "net/http.Request",
+          "field_name": "RemoteAddr",
+          "offsets": [
+            {
+              "offset": 176,
+              "version": "1.20.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.20.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.20"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.19.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.19"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.18.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.18"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.17.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.17"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.16.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.16"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.15.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.14.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.13.1"
+            },
+            {
+              "offset": 176,
+              "version": "1.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.17"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.16"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.15"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.14"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.13"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.12"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.11"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.10"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.9"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.8"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.7"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.6"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.5"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.4"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.3"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.2"
+            },
+            {
+              "offset": 176,
+              "version": "1.12.1"
+            },
+            {
+              "offset": 176,
               "version": "1.12"
             }
           ]
@@ -3327,6 +3399,18 @@
             {
               "offset": 8,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 8,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 8,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 8,
+              "version": "v1.55.0-dev"
             }
           ]
         },
@@ -3853,6 +3937,18 @@
             {
               "offset": 8,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 8,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 8,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 8,
+              "version": "v1.55.0-dev"
             }
           ]
         },
@@ -4379,6 +4475,18 @@
             {
               "offset": 80,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 80,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 80,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 80,
+              "version": "v1.55.0-dev"
             }
           ]
         },
@@ -4905,6 +5013,18 @@
             {
               "offset": 0,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 0,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 0,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 0,
+              "version": "v1.55.0-dev"
             }
           ]
         },
@@ -5431,6 +5551,18 @@
             {
               "offset": 32,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 32,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 32,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 32,
+              "version": "v1.55.0-dev"
             }
           ]
         },
@@ -5957,6 +6089,18 @@
             {
               "offset": 24,
               "version": "v1.53.0-dev"
+            },
+            {
+              "offset": 24,
+              "version": "v1.53.0"
+            },
+            {
+              "offset": 24,
+              "version": "v1.54.0"
+            },
+            {
+              "offset": 24,
+              "version": "v1.55.0-dev"
             }
           ]
         }

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
@@ -108,7 +108,7 @@ func (g *gorillaMuxInstrumentor) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	up, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeGorillaMuxServeHTTP, &link.UprobeOptions{
-		Offset: offset,
+		Address: offset,
 	})
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (g *gorillaMuxInstrumentor) Load(ctx *context.InstrumentorContext) error {
 
 	for _, ret := range retOffsets {
 		retProbe, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeGorillaMuxServeHTTP_Returns, &link.UprobeOptions{
-			Offset: ret,
+			Address: ret,
 		})
 		if err != nil {
 			return err

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
@@ -101,7 +101,7 @@ func (g *grpcInstrumentor) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	up, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeClientConnInvoke, &link.UprobeOptions{
-		Offset: offset,
+		Address: offset,
 	})
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func (g *grpcInstrumentor) Load(ctx *context.InstrumentorContext) error {
 
 	for _, ret := range retOffsets {
 		retProbe, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeClientConnInvokeReturns, &link.UprobeOptions{
-			Offset: ret,
+			Address: ret,
 		})
 		if err != nil {
 			return err
@@ -136,7 +136,7 @@ func (g *grpcInstrumentor) Load(ctx *context.InstrumentorContext) error {
 	}
 	for _, whOffset := range whOffsets {
 		whProbe, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeHttp2ClientCreateHeaderFields, &link.UprobeOptions{
-			Offset: whOffset,
+			Address: whOffset,
 		})
 		if err != nil {
 			return err

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
@@ -127,7 +127,7 @@ func (g *grpcServerInstrumentor) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	up, err := ctx.Executable.Uprobe("", uprobeObj, &link.UprobeOptions{
-		Offset: offset,
+		Address: offset,
 	})
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (g *grpcServerInstrumentor) Load(ctx *context.InstrumentorContext) error {
 
 	for _, ret := range retOffsets {
 		retProbe, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeServerHandleStreamReturns, &link.UprobeOptions{
-			Offset: ret,
+			Address: ret,
 		})
 		if err != nil {
 			return err
@@ -154,7 +154,7 @@ func (g *grpcServerInstrumentor) Load(ctx *context.InstrumentorContext) error {
 		return err
 	}
 	hProbe, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeDecodeStateDecodeHeader, &link.UprobeOptions{
-		Offset: headerOffset,
+		Address: headerOffset,
 	})
 	if err != nil {
 		return err

--- a/pkg/instrumentors/bpf/net/http/server/probe.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe.go
@@ -124,7 +124,7 @@ func (h *httpServerInstrumentor) registerProbes(ctx *context.InstrumentorContext
 	}
 
 	up, err := ctx.Executable.Uprobe("", h.bpfObjects.UprobeServerMuxServeHTTP, &link.UprobeOptions{
-		Offset: offset,
+		Address: offset,
 	})
 	if err != nil {
 		logger.V(1).Info("could not insert start uprobe. Skipping",
@@ -136,7 +136,7 @@ func (h *httpServerInstrumentor) registerProbes(ctx *context.InstrumentorContext
 
 	for _, ret := range retOffsets {
 		retProbe, err := ctx.Executable.Uprobe("", h.bpfObjects.UprobeServerMuxServeHTTP_Returns, &link.UprobeOptions{
-			Offset: ret,
+			Address: ret,
 		})
 		if err != nil {
 			logger.Error(err, "could not insert return uprobe. Skipping")

--- a/test/e2e/gorillamux/Dockerfile
+++ b/test/e2e/gorillamux/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.19
+WORKDIR /sample-app
+COPY . .
+RUN go build -o main

--- a/test/e2e/gorillamux/Dockerfile
+++ b/test/e2e/gorillamux/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 WORKDIR /sample-app
 COPY . .
 RUN go build -o main

--- a/test/e2e/gorillamux/go.mod
+++ b/test/e2e/gorillamux/go.mod
@@ -1,0 +1,5 @@
+module github.com/open-telemetry/opentelemetry-go-instrumentation/e2e/gorillamux
+
+go 1.20
+
+require github.com/gorilla/mux v1.8.0

--- a/test/e2e/gorillamux/go.sum
+++ b/test/e2e/gorillamux/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/test/e2e/gorillamux/main.go
+++ b/test/e2e/gorillamux/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/users/{user}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		user := vars["user"]
+		fmt.Fprintf(w, "Hello user %s\n", user)
+	})
+	go http.ListenAndServe(":8080", r)
+
+	time.Sleep(5 * time.Second)
+
+	resp, err := http.Get("http://localhost:8080/users/foo")
+	if err != nil {
+		log.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Body: %s\n", string(body))
+	_ = resp.Body.Close()
+}

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -69,9 +69,9 @@
               "kind": 2,
               "name": "/users/foo",
               "parentSpanId": "",
-              "spanId": "f16618fb345a863b",
+              "spanId": "xxxxx",
               "status": {},
-              "traceId": "115a7a7255825337b37a9f979beb8ee1"
+              "traceId": "xxxxx"
             }
           ]
         }

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -1,0 +1,52 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "sample-app"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "go"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "github.com/gorilla/mux"
+          },
+          "spans": [
+            {
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "kind": 2,
+              "parentSpanId": "",
+              "spanId": "",
+              "status": {},
+              "traceId": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -20,6 +20,34 @@
       "scopeSpans": [
         {
           "scope": {
+            "name": "net/http"
+          },
+          "spans": [
+            {
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "kind": 2,
+              "parentSpanId": "",
+              "spanId": "cc1a651bfd03c2ae",
+              "status": {},
+              "traceId": "c7f2eb84d6cf61c076e95b0a7d5eb406"
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "github.com/gorilla/mux"
           },
           "spans": [

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -20,34 +20,6 @@
       "scopeSpans": [
         {
           "scope": {
-            "name": "net/http"
-          },
-          "spans": [
-            {
-              "attributes": [
-                {
-                  "key": "http.method",
-                  "value": {
-                    "stringValue": "GET"
-                  }
-                },
-                {
-                  "key": "http.target",
-                  "value": {
-                    "stringValue": ""
-                  }
-                }
-              ],
-              "kind": 2,
-              "parentSpanId": "",
-              "spanId": "cc1a651bfd03c2ae",
-              "status": {},
-              "traceId": "c7f2eb84d6cf61c076e95b0a7d5eb406"
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "github.com/gorilla/mux"
           },
           "spans": [
@@ -71,6 +43,35 @@
               "spanId": "",
               "status": {},
               "traceId": ""
+            }
+          ]
+        },
+        {
+          "scope": {
+            "name": "net/http"
+          },
+          "spans": [
+            {
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/users/foo"
+                  }
+                }
+              ],
+              "kind": 2,
+              "name": "/users/foo",
+              "parentSpanId": "",
+              "spanId": "f16618fb345a863b",
+              "status": {},
+              "traceId": "115a7a7255825337b37a9f979beb8ee1"
             }
           ]
         }

--- a/test/e2e/nethttp/Dockerfile
+++ b/test/e2e/nethttp/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.19
+WORKDIR /sample-app
+COPY . .
+RUN go build -o main

--- a/test/e2e/nethttp/Dockerfile
+++ b/test/e2e/nethttp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.20
 WORKDIR /sample-app
 COPY . .
 RUN go build -o main

--- a/test/e2e/nethttp/go.mod
+++ b/test/e2e/nethttp/go.mod
@@ -1,0 +1,3 @@
+module github.com/open-telemetry/opentelemetry-go-instrumentation/e2e/nethttp
+
+go 1.20

--- a/test/e2e/nethttp/main.go
+++ b/test/e2e/nethttp/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+func hello(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "hello\n")
+}
+
+func main() {
+	http.HandleFunc("/hello", hello)
+	go http.ListenAndServe(":8080", nil)
+
+	time.Sleep(5 * time.Second)
+
+	resp, err := http.Get("http://localhost:8080/hello")
+	if err != nil {
+		log.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Body: %s\n", string(body))
+	_ = resp.Body.Close()
+}

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -41,9 +41,9 @@
               "kind": 2,
               "name": "/hello",
               "parentSpanId": "",
-              "spanId": "c204b0297fca1912",
+              "spanId": "xxxxx",
               "status": {},
-              "traceId": "875ab5241c9db2ea5286a6643f01cf8c"
+              "traceId": "xxxxx"
             },
             {
               "attributes": [

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -1,0 +1,52 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "sample-app"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "go"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "net/http"
+          },
+          "spans": [
+            {
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "kind": 2,
+              "parentSpanId": "",
+              "spanId": "",
+              "status": {},
+              "traceId": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -28,6 +28,27 @@
                 {
                   "key": "http.method",
                   "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "kind": 2,
+              "parentSpanId": "",
+              "spanId": "a12c8ff240d71c9b",
+              "status": {},
+              "traceId": "ff04ebd7ec9ae28959ceb0e26efde31d"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.method",
+                  "value": {
                     "stringValue": ""
                   }
                 },

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -34,15 +34,16 @@
                 {
                   "key": "http.target",
                   "value": {
-                    "stringValue": ""
+                    "stringValue": "/hello"
                   }
                 }
               ],
               "kind": 2,
+              "name": "/hello",
               "parentSpanId": "",
-              "spanId": "a12c8ff240d71c9b",
+              "spanId": "c204b0297fca1912",
               "status": {},
-              "traceId": "ff04ebd7ec9ae28959ceb0e26efde31d"
+              "traceId": "875ab5241c9db2ea5286a6643f01cf8c"
             },
             {
               "attributes": [


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/39

This adds an e2e test matrix (largely based on [collector-contrib's tests](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a45376db04289be6e0ca98276d26d8b504d9cad5/.github/workflows/e2e-tests.yml)) that does the following:

1. Builds the auto-instrumentation agent, launcher (to be removed with https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/40), and sample apps using each supported library
2. Spins up a kind cluster
3. Starts an otel collector with trace receiver and file exporter
4. Starts the sample app for that library
5. The sample app calls itself to generate trace data
6. Copies the file exporter output to a local fixture
7. Checks for changes to the current fixture, ignoring/removing timestamps

I used a k8s cluster instead of just running the binaries for a couple reasons: First, I wanted to just use a collector image from upstream rather than building it ourselves. Second, k8s gives some nice orchestration around starting up and stopping these processes that works well as a Github action. I couldn't find a good way to build local binaries and have those run in the background, while moving on to the next Workflow step, and checking that everything had completed successfully.

The steps are basically copied to a new `make fixture-$LIBRARY` target that lets you generate these fixtures. Eg, `make fixture-nethttp` will run all the steps from above. Failures in these tests could indicate a legitimate update to the fixtures, so updating them locally will be useful.

I added sample apps for gorillamux and net/http. If someone else wants to add a gRPC app, I think the first 2 serve as a good example. New libraries should be able to drop in similarly.