### PR TITLE
Add missing errors import to pkg/process/analyze.go

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Build auto-instrumentation
+        run: |
+          IMG=otel-go-instrumentation make docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35 as builder
+FROM fedora:37 as builder
 RUN dnf install clang llvm make libbpf-devel -y
 RUN curl -LO https://go.dev/dl/go1.20.linux-amd64.tar.gz && tar -C /usr/local -xzf go*.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/pkg/process/analyze.go
+++ b/pkg/process/analyze.go
@@ -17,6 +17,7 @@ package process
 import (
 	"debug/elf"
 	"debug/gosym"
+	"errors"
 	"fmt"
 	"os"
 	"strings"


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/34 added a call to `errors` in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/34/files#diff-bcde6514e171538383da5f36aa35cc83afb444c5fb30c71429e01a7704e380dfR171 missing the import:

```
# github.com/open-telemetry/opentelemetry-go-instrumentation/pkg/process
pkg/process/analyze.go:171:15: undefined: errors
make: *** [Makefile:33: build] Error 1
```

This also adds a basic CI check that runs `make build`