### PR TITLE
Update generated files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,24 @@ on:
   pull_request:
 
 jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y clang llvm libbpf-dev
+      - name: make generate
+        run: |
+          make generate
+      - name: verify output
+        run: |
+          git diff --exit-code || (echo 'generated diff, please run "make generate"')
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel.go
@@ -13,6 +13,19 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+type bpfHttpRequestT struct {
+	StartTime uint64
+	EndTime   uint64
+	Method    [100]int8
+	Path      [100]int8
+	Sc        bpfSpanContext
+}
+
+type bpfSpanContext struct {
+	TraceID [16]uint8
+	SpanID  [8]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel.go
@@ -13,6 +13,23 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+type bpfGrpcRequestT struct {
+	StartTime uint64
+	EndTime   uint64
+	Method    [50]int8
+	Target    [50]int8
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
+	_         [4]byte
+}
+
+type bpfHeadersBuff struct{ Buff [500]uint8 }
+
+type bpfSpanContext struct {
+	TraceID [16]uint8
+	SpanID  [8]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel.go
@@ -13,6 +13,20 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+type bpfGrpcRequestT struct {
+	StartTime uint64
+	EndTime   uint64
+	Method    [100]int8
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
+	_         [4]byte
+}
+
+type bpfSpanContext struct {
+	TraceID [16]uint8
+	SpanID  [8]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/pkg/instrumentors/bpf/net/http/server/bpf_bpfel.go
+++ b/pkg/instrumentors/bpf/net/http/server/bpf_bpfel.go
@@ -13,6 +13,20 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+type bpfHttpRequestT struct {
+	StartTime uint64
+	EndTime   uint64
+	Method    [6]int8
+	Path      [100]int8
+	Sc        bpfSpanContext
+	_         [6]byte
+}
+
+type bpfSpanContext struct {
+	TraceID [16]uint8
+	SpanID  [8]uint8
+}
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)


### PR DESCRIPTION
One of the recent changes (I think https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/55) caused changes to the output of `make generate`. This commits those changes and adds a check for them in the future.