### PR TITLE
Add shutdown sleep in e2e sample apps

### DIFF
--- a/test/e2e/gorillamux/main.go
+++ b/test/e2e/gorillamux/main.go
@@ -20,6 +20,7 @@ func main() {
 	})
 	go http.ListenAndServe(":8080", r)
 
+	// give time for auto-instrumentation to start up
 	time.Sleep(5 * time.Second)
 
 	resp, err := http.Get("http://localhost:8080/users/foo")
@@ -33,4 +34,7 @@ func main() {
 
 	log.Printf("Body: %s\n", string(body))
 	_ = resp.Body.Close()
+
+	// give time for auto-instrumentation to report signal
+	time.Sleep(5 * time.Second)
 }

--- a/test/e2e/nethttp/main.go
+++ b/test/e2e/nethttp/main.go
@@ -16,6 +16,7 @@ func main() {
 	http.HandleFunc("/hello", hello)
 	go http.ListenAndServe(":8080", nil)
 
+	// give time for auto-instrumentation to start up
 	time.Sleep(5 * time.Second)
 
 	resp, err := http.Get("http://localhost:8080/hello")
@@ -29,4 +30,7 @@ func main() {
 
 	log.Printf("Body: %s\n", string(body))
 	_ = resp.Body.Close()
+
+	// give time for auto-instrumentation to report signal
+	time.Sleep(5 * time.Second)
 }


### PR DESCRIPTION
Running these locally, I think there is a race where the sample app kills itself (and the auto-instrumentation agent) before the agent can report the traces (or possibly just some of the traces).

Based on these timestamps:
```
...
{"level":"info","ts":1680703487.2847497,"logger":"allocator","caller":"allocator/allocator_linux.go:39","msg":"Loading allocator","start_addr":140696813170688,"end_addr":140696825753600}
{"level":"info","ts":1680703487.2932906,"caller":"instrumentors/runner.go:83","msg":"loading instrumentor","name":"net/http"}
{"level":"info","ts":1680703487.2940571,"caller":"inject/injector.go:83","msg":"Injecting variables","vars":{"is_registers_abi":true,"method_ptr_pos":0,"path_ptr_pos":56,"url_ptr_pos":16}}
{"level":"info","ts":1680703487.3445415,"caller":"instrumentors/runner.go:92","msg":"loaded instrumentors to memory","total_instrumentors":1}
{"level":"info","ts":1680703490.9373105,"caller":"opentelemetry/controller.go:59","msg":"got event","attrs":[{"Key":"http.method","Value":{"Type":"STRING","Value":"GET"}},{"Key":"http.target","Value":{"Type":"STRING","Value":"/hello"}}]}
{"level":"info","ts":1680703490.9388587,"caller":"opentelemetry/controller.go:59","msg":"got event","attrs":[{"Key":"http.method","Value":{"Type":"STRING","Value":""}},{"Key":"http.target","Value":{"Type":"STRING","Value":""}}]}
{"level":"info","ts":1680703490.9463415,"caller":"cli/main.go:61","msg":"Got SIGTERM, cleaning up.."}
{"level":"info","ts":1680703490.946396,"caller":"instrumentors/runner.go:46","msg":"shutting down all instrumentors due to signal"}
{"level":"info","ts":1680703490.9464152,"caller":"server/probe.go:201","msg":"closing net/http instrumentor"}
```

The instrumentation event is received at the same time as the SIGTERM. Adding another 5 second sleep to make totally sure there is enough time for everything to flush.