### PR TITLE
Fix make generate test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           make generate
       - name: verify output
         run: |
-          git diff --exit-code || (echo 'generated diff, please run "make generate"')
+          git diff --exit-code || (echo 'generated diff, please run "make generate"' && exit 1)
   docker-build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The test for `make generate` didn't actually return an error code if it failed, see https://github.com/open-telemetry/opentelemetry-go-instrumentation/actions/runs/4638568934/jobs/8208494539?pr=40#step:6:17 for an example of a run that failed but "passed"