### PR TITLE
[chore] Remove DockerHub from release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,37 +5,33 @@ on:
       - 'v*.*.*'
 jobs:
   build-and-push-image:
-    env:
-      IMAGE_NAME: autoinstrumentation-go
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/checkout@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            otel/${{ env.IMAGE_NAME }}
-            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,29 +11,29 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.5.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v4.4.0
         with:
-          images: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+          images: ghcr.io/${{ github.repository }}/autoinstrumentation-go
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.0.0
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR removes DockerHub from the release destinations since it was having issues during the v0.1.0-alpha release. Instead we push only to ghcr, aligning our workflow closely with `opentelemetry-operator`, which is the only other OTel repo (that I found) using `docker/metadata-action`.

 See https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/66 for complete details.

Test of this workflow update can be seen here: https://github.com/TylerHelmuth/opentelemetry-go-instrumentation/actions/runs/4746843071