### PR TITLE
[feat] Update target exe environment variable name

### DIFF
--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -27,7 +27,7 @@ spec:
         image: otel-go-instrumentation
         imagePullPolicy: IfNotPresent
         env:
-        - name: OTEL_TARGET_EXE
+        - name: OTEL_GO_AUTO_TARGET_EXE
           value: /sample-app/main
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "test-opentelemetry-collector:4317"

--- a/docs/getting-started/emojivoto-instrumented.yaml
+++ b/docs/getting-started/emojivoto-instrumented.yaml
@@ -58,7 +58,7 @@ spec:
         - name: emojivoto-emoji-instrumentation
           image: keyval/otel-go-agent:v0.6.0
           env:
-            - name: OTEL_TARGET_EXE
+            - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-emoji-svc
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "jaeger:4317"
@@ -140,7 +140,7 @@ spec:
         - name: emojivoto-voting-instrumentation
           image: keyval/otel-go-agent:v0.6.0
           env:
-            - name: OTEL_TARGET_EXE
+            - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-voting-svc
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "jaeger:4317"
@@ -224,7 +224,7 @@ spec:
         - name: emojivoto-web-instrumentation
           image: keyval/otel-go-agent:v0.6.0
           env:
-            - name: OTEL_TARGET_EXE
+            - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-web
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "jaeger:4317"

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -7,7 +7,7 @@ We aim to bring the automatic instrumentation experience found in languages like
 - No code changes required - any Go application can be instrumented without modifying the source code.
 - Support wide range of Go applications - instrumentation is supported for Go version 1.12 and above. In addition, a common practice for Go applications is to shrink the binary size by stripping debug symbols via `go build -ldflags "-s -w"`. This instrumentation works for stripped binaries as well.
 - Configuration is done via `OTEL_*` environment variables according to [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration).
-  **In order to inject instrumentation into your process, set the `OTEL_TARGET_EXE` environment variable to the path of the target executable. This is not a part of the OTEL specification mentioned above.**
+  **In order to inject instrumentation into your process, set the `OTEL_GO_AUTO_TARGET_EXE` environment variable to the path of the target executable. This is not a part of the OTEL specification mentioned above.**
 - Instrumented libraries follow the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification) and semantic conventions to produce standard OpenTelemetry data.
 
 ## Why eBPF

--- a/pkg/process/args.go
+++ b/pkg/process/args.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	ExePathEnvVar = "OTEL_TARGET_EXE"
+	ExePathEnvVar = "OTEL_GO_AUTO_TARGET_EXE"
 )
 
 type TargetArgs struct {


### PR DESCRIPTION
Updates the target exe environment variable name and usage to `OTEL_GO_AUTO_TARGET_EXE` to follow [OTel specific language environment variable pattern](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#language-specific-environment-variables).

- Closes #96 