### PR TITLE
[chore] update e2e tests to use BATS assertions

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
       - name: Build auto-instrumentation
         run: |
           IMG=otel-go-instrumentation:latest make docker-build

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -73,4 +73,4 @@ jobs:
           kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json
       - name: verify output
         run: |
-          bats ./test/e2e/$(LIBRARY)/verify.bats
+          bats ./test/e2e/${{ matrix.library }}/verify.bats

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -70,7 +70,8 @@ jobs:
           kubectl wait --for=condition=Complete --timeout=60s job/sample-job
       - name: copy telemetry trace output
         run: |
-          kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json
-      - name: verify output
+          kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces-orig.json
+          rm -f ./test/e2e/${{ matrix.library }}/traces.json
+      - name: verify output and redact to traces.json
         run: |
           bats ./test/e2e/${{ matrix.library }}/verify.bats

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -68,9 +68,7 @@ jobs:
           kubectl wait --for=condition=Complete --timeout=60s job/sample-job
       - name: copy telemetry trace output
         run: |
-          kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json.tmp
-          jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano) | .resourceSpans[].scopeSpans[].spans[].spanId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans[].spans[].traceId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans|=sort_by(.scope.name)' ./test/e2e/${{ matrix.library }}/traces.json.tmp | jq --sort-keys . > ./test/e2e/${{ matrix.library }}/traces.json
-          rm ./test/e2e/${{ matrix.library }}/traces.json.tmp
+          kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/${{ matrix.library }}/traces.json
       - name: verify output
         run: |
-          make check-clean-work-tree
+          bats ./test/e2e/$(LIBRARY)/verify.bats

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,8 @@ fixtures/%:
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job
-	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces.json.tmp
-	jq 'del(.resourceSpans[].scopeSpans[].spans[].endTimeUnixNano, .resourceSpans[].scopeSpans[].spans[].startTimeUnixNano) | .resourceSpans[].scopeSpans[].spans[].spanId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans[].spans[].traceId|= (if . != "" then "xxxxx" else . end) | .resourceSpans[].scopeSpans|=sort_by(.scope.name)' ./test/e2e/$(LIBRARY)/traces.json.tmp | jq --sort-keys . > ./test/e2e/$(LIBRARY)/traces.json
-	rm ./test/e2e/$(LIBRARY)/traces.json.tmp
+	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces.json
+	bats ./test/e2e/$(LIBRARY)/verify.bats
 	kind delete cluster
 
 .PHONY: prerelease

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,8 @@ fixtures/%:
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job
-	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces.json
+	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./test/e2e/$(LIBRARY)/traces-orig.json
+	rm -f ./test/e2e/$(LIBRARY)/traces.json
 	bats ./test/e2e/$(LIBRARY)/verify.bats
 	kind delete cluster
 

--- a/test/e2e/gin/verify.bats
+++ b/test/e2e/gin/verify.bats
@@ -2,17 +2,36 @@
 
 load ../../test_helpers/utilities
 
+LIBRARY_NAME="github.com/gin-gonic/gin"
+
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "gorillamux :: emits a span name '{http.method} {http.route}' (per semconv)" {
-  result=$(span_names_for "github.com/gin-gonic/gin")
-  assert_equal "$result" '"GET /hello"'
+# TODO: span name should include http.method per spec
+# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+  result=$(span_names_for ${LIBRARY_NAME})
+  assert_equal "$result" '"/hello-gin"'
 }
 
-@test "gorillamux :: trace ID present in all spans" {
-  result=$(spans_from_scope_named "github.com/gin-gonic/gin" | jq ".traceId")
-  assert_equal "$result" 'hey'
+@test "${LIBRARY_NAME} :: includes http.method attribute" {
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+  assert_equal "$result" '"GET"'
+}
+
+@test "${LIBRARY_NAME} :: includes http.target attribute" {
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+  assert_equal "$result" '"/hello-gin"'
+}
+
+@test "${LIBRARY_NAME} :: trace ID present in all spans" {
+  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  assert_not_empty "$result"
+}
+
+@test "${LIBRARY_NAME} :: span ID present in all spans" {
+  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  assert_not_empty "$result"
 }

--- a/test/e2e/gin/verify.bats
+++ b/test/e2e/gin/verify.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load ../../test_helpers/utilities
+
+@test "go-auto :: includes service.name in resource attributes" {
+  result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
+  assert_equal "$result" '"sample-app"'
+}
+
+@test "gorillamux :: emits a span name '{http.method} {http.route}' (per semconv)" {
+  result=$(span_names_for "github.com/gin-gonic/gin")
+  assert_equal "$result" '"GET /hello"'
+}
+
+@test "gorillamux :: trace ID present in all spans" {
+  result=$(spans_from_scope_named "github.com/gin-gonic/gin" | jq ".traceId")
+  assert_equal "$result" 'hey'
+}

--- a/test/e2e/gin/verify.bats
+++ b/test/e2e/gin/verify.bats
@@ -9,11 +9,9 @@ LIBRARY_NAME="github.com/gin-gonic/gin"
   assert_equal "$result" '"sample-app"'
 }
 
-# TODO: span name should include http.method per spec
-# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
-@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
   result=$(span_names_for ${LIBRARY_NAME})
-  assert_equal "$result" '"/hello-gin"'
+  assert_equal "$result" '"GET /hello-gin"'
 }
 
 @test "${LIBRARY_NAME} :: includes http.method attribute" {

--- a/test/e2e/gin/verify.bats
+++ b/test/e2e/gin/verify.bats
@@ -24,12 +24,17 @@ LIBRARY_NAME="github.com/gin-gonic/gin"
   assert_equal "$result" '"/hello-gin"'
 }
 
-@test "${LIBRARY_NAME} :: trace ID present in all spans" {
-  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
+  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${LIBRARY_NAME} :: span ID present in all spans" {
-  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
+  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+}
+
+@test "${LIBRARY_NAME} :: expected (redacted) trace output" {
+  redact_json
+  assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -2,17 +2,38 @@
 
 load ../../test_helpers/utilities
 
+LIBRARY_NAME="github.com/gorilla/mux"
+# TODO: spans currently show net/http as the library name
+TEMP_LIBRARY_NAME="net/http"
+
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "gorillamux :: emits a span name '{http.method} {http.route}' (per semconv)" {
-  result=$(span_names_for "github.com/gorilla/mux")
-  assert_equal "$result" '"GET /hello"'
+# TODO: span name should include http.method per spec
+# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+  result=$(span_names_for ${TEMP_LIBRARY_NAME})
+  assert_equal "$result" '"/users/foo"'
 }
 
-@test "gorillamux :: trace ID present in all spans" {
-  result=$(spans_from_scope_named "github.com/gorilla/mux" | jq ".traceId")
-  assert_equal "$result" 'hey'
+@test "${LIBRARY_NAME} :: includes http.method attribute" {
+  result=$(span_attributes_for ${TEMP_LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+  assert_equal "$result" '"GET"'
+}
+
+@test "${LIBRARY_NAME} :: includes http.target attribute" {
+  result=$(span_attributes_for ${TEMP_LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+  assert_equal "$result" '"/users/foo"'
+}
+
+@test "${LIBRARY_NAME} :: trace ID present in all spans" {
+  result=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".traceId")
+  assert_not_empty "$result"
+}
+
+@test "${LIBRARY_NAME} :: span ID present in all spans" {
+  result=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".spanId")
+  assert_not_empty "$result"
 }

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load ../../test_helpers/utilities
+
+@test "go-auto :: includes service.name in resource attributes" {
+  result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
+  assert_equal "$result" '"sample-app"'
+}
+
+@test "gorillamux :: emits a span name '{http.method} {http.route}' (per semconv)" {
+  result=$(span_names_for "github.com/gorilla/mux")
+  assert_equal "$result" '"GET /hello"'
+}
+
+@test "gorillamux :: trace ID present in all spans" {
+  result=$(spans_from_scope_named "github.com/gorilla/mux" | jq ".traceId")
+  assert_equal "$result" 'hey'
+}

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -27,12 +27,12 @@ TEMP_LIBRARY_NAME="net/http"
 }
 
 @test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  trace_id=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  span_id=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -3,8 +3,6 @@
 load ../../test_helpers/utilities
 
 LIBRARY_NAME="github.com/gorilla/mux"
-# TODO: spans currently show net/http as the library name
-TEMP_LIBRARY_NAME="net/http"
 
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
@@ -12,27 +10,27 @@ TEMP_LIBRARY_NAME="net/http"
 }
 
 @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
-  result=$(span_names_for ${TEMP_LIBRARY_NAME})
+  result=$(span_names_for ${LIBRARY_NAME})
   assert_equal "$result" '"GET /users/foo"'
 }
 
 @test "${LIBRARY_NAME} :: includes http.method attribute" {
-  result=$(span_attributes_for ${TEMP_LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
   assert_equal "$result" '"GET"'
 }
 
 @test "${LIBRARY_NAME} :: includes http.target attribute" {
-  result=$(span_attributes_for ${TEMP_LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
   assert_equal "$result" '"/users/foo"'
 }
 
 @test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".traceId")
+  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".spanId")
+  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -11,11 +11,9 @@ TEMP_LIBRARY_NAME="net/http"
   assert_equal "$result" '"sample-app"'
 }
 
-# TODO: span name should include http.method per spec
-# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
-@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
   result=$(span_names_for ${TEMP_LIBRARY_NAME})
-  assert_equal "$result" '"/users/foo"'
+  assert_equal "$result" '"GET /users/foo"'
 }
 
 @test "${LIBRARY_NAME} :: includes http.method attribute" {

--- a/test/e2e/gorillamux/verify.bats
+++ b/test/e2e/gorillamux/verify.bats
@@ -26,12 +26,17 @@ TEMP_LIBRARY_NAME="net/http"
   assert_equal "$result" '"/users/foo"'
 }
 
-@test "${LIBRARY_NAME} :: trace ID present in all spans" {
-  result=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".traceId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
+  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${LIBRARY_NAME} :: span ID present in all spans" {
-  result=$(spans_from_scope_named ${TEMP_LIBRARY_NAME} | jq ".spanId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
+  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+}
+
+@test "${LIBRARY_NAME} :: expected (redacted) trace output" {
+  redact_json
+  assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/test/e2e/nethttp/verify.bats
+++ b/test/e2e/nethttp/verify.bats
@@ -2,17 +2,36 @@
 
 load ../../test_helpers/utilities
 
+LIBRARY_NAME="net/http"
+
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "net/http :: emits a span name '{http.method} {http.route}' (per semconv)" {
-  result=$(span_names_for "net/http")
-  assert_equal "$result" '"GET /hello"'
+# TODO: span name should include http.method per spec
+# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+  result=$(span_names_for ${LIBRARY_NAME})
+  assert_equal "$result" '"/hello"'
 }
 
-@test "net/http :: trace ID present in all spans" {
-  result=$(spans_from_scope_named "net/http" | jq ".traceId")
-  assert_equal "$result" 'hey'
+@test "${LIBRARY_NAME} :: includes http.method attribute" {
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+  assert_equal "$result" '"GET"'
+}
+
+@test "${LIBRARY_NAME} :: includes http.target attribute" {
+  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+  assert_equal "$result" '"/hello"'
+}
+
+@test "${LIBRARY_NAME} :: trace ID present in all spans" {
+  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  assert_not_empty "$result"
+}
+
+@test "${LIBRARY_NAME} :: span ID present in all spans" {
+  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  assert_not_empty "$result"
 }

--- a/test/e2e/nethttp/verify.bats
+++ b/test/e2e/nethttp/verify.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load ../../test_helpers/utilities
+
+@test "go-auto :: includes service.name in resource attributes" {
+  result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
+  assert_equal "$result" '"sample-app"'
+}
+
+@test "net/http :: emits a span name '{http.method} {http.route}' (per semconv)" {
+  result=$(span_names_for "net/http")
+  assert_equal "$result" '"GET /hello"'
+}
+
+@test "net/http :: trace ID present in all spans" {
+  result=$(spans_from_scope_named "net/http" | jq ".traceId")
+  assert_equal "$result" 'hey'
+}

--- a/test/e2e/nethttp/verify.bats
+++ b/test/e2e/nethttp/verify.bats
@@ -9,11 +9,9 @@ LIBRARY_NAME="net/http"
   assert_equal "$result" '"sample-app"'
 }
 
-# TODO: span name should include http.method per spec
-# @test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
-@test "${LIBRARY_NAME} :: emits a span name '{http.route}'" {
+@test "${LIBRARY_NAME} :: emits a span name '{http.method} {http.target}' (per semconv)" {
   result=$(span_names_for ${LIBRARY_NAME})
-  assert_equal "$result" '"/hello"'
+  assert_equal "$result" '"GET /hello"'
 }
 
 @test "${LIBRARY_NAME} :: includes http.method attribute" {

--- a/test/e2e/nethttp/verify.bats
+++ b/test/e2e/nethttp/verify.bats
@@ -24,12 +24,17 @@ LIBRARY_NAME="net/http"
   assert_equal "$result" '"/hello"'
 }
 
-@test "${LIBRARY_NAME} :: trace ID present in all spans" {
-  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
+  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${LIBRARY_NAME} :: span ID present in all spans" {
-  result=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
-  assert_not_empty "$result"
+@test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
+  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+}
+
+@test "${LIBRARY_NAME} :: expected (redacted) trace output" {
+  redact_json
+  assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/test/test_helpers/utilities.bash
+++ b/test/test_helpers/utilities.bash
@@ -57,3 +57,23 @@ assert_equal() {
 	fi
 }
 
+assert_not_empty() {
+	EMPTY=(\"\")
+	if [[ "$1" == "${EMPTY}" ]]; then
+		{
+			echo
+			echo "-- 💥 value is empty 💥 --"
+			echo "value : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+		else
+		{
+			echo
+			echo "-- ✅ value is not empty ✅ --"
+			echo "value : $1"
+		} >&3 # output success to STDOUT
+			return 0
+	fi
+}

--- a/test/test_helpers/utilities.bash
+++ b/test/test_helpers/utilities.bash
@@ -1,0 +1,59 @@
+# DATA RETRIEVERS
+
+# Returns a list of span names emitted by a given library/scope
+	# $1 - library/scope name
+span_names_for() {
+	spans_from_scope_named $1 | jq '.name'
+}
+
+# Returns a list of attributes emitted by a given library/scope
+span_attributes_for() {
+	# $1 - library/scope name
+
+	spans_from_scope_named $1 | \
+		jq ".attributes[]"
+}
+
+# Returns a list of all resource attributes
+resource_attributes_received() {
+	spans_received | jq ".resource.attributes[]?"
+}
+
+# Returns an array of all spans emitted by a given library/scope
+	# $1 - library/scope name
+spans_from_scope_named() {
+	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
+}
+
+# Returns an array of all spans received
+spans_received() {
+	jq ".resourceSpans[]?" "${BATS_TEST_DIRNAME}/traces.json"
+}
+
+# Returns the content of the log file produced by a collector
+# and located in the same directory as the BATS test file
+# loading this helper script.
+json_output() {
+	cat "${BATS_TEST_DIRNAME}/traces.json"
+}
+
+# ASSERTION HELPERS
+
+# Fail and display details if the expected and actual values do not
+# equal. Details include both values.
+#
+# Inspired by bats-assert * bats-support, but dramatically simplified
+assert_equal() {
+	if [[ $1 != "$2" ]]; then
+		{
+			echo
+			echo "-- 💥 values are not equal 💥 --"
+			echo "expected : $2"
+			echo "actual   : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}
+


### PR DESCRIPTION
## Short description of the changes

- Use [bats](https://bats-core.readthedocs.io/en/stable/) for e2e testing
- Modify step in workflow to use BATS to make more precise assertions about the unredacted trace data
- Moves the redaction logic for the traces.json file to the BATS test helpers and asserts no-git-difference in the test suites
- Add utilities test helper for more clarity (specifically includes named functions that are easier to reason about)

This can be run locally as well. You will get a `traces-orig.json` file for each test run, and from there you can further work with the tests by running `bats verify.bats` in the directory if you install bats locally.

Note I added a TODO for gorilla/mux spans coming out with a scope name of net/http, probably as a result of being produced by the net/http probe. This is a PR for updating tests, so I propose fixing the probe source is out of scope and  should be addressed in a separate PR.

## How to verify that this has the expected result

e2e tests pass with expected results. Running locally with `make fixture-nethttp` and the others has expected results, and also creates a clean `traces.json` with expected output.

To see an example of a fail locally, run one of the e2e tests (e.g. `make fixture-gin`), change directory to `test/e2e/gin`, change the local `traces-org.json` (maybe change the real span ID to `"nope"`), and run `bats verify.bats`.

![e2e-fail-gin](https://github.com/open-telemetry/opentelemetry-go-instrumentation/assets/517302/29072712-4dce-4569-83c8-6ffad60811f5)
