### PR TITLE
docs: update emojivoto example

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -30,7 +30,7 @@ The different emojivoto applications are communicating via gRPC. Instrumenting t
 Run the following command:
 
 ```shell
-kubectl apply -k github.com/open-telemetry/opentelemetry-go-instrumentation/docs/getting-started/emojivoto
+kubectl apply -k emojivoto/
 ```
 
 ### Deploying Jaeger UI
@@ -38,7 +38,7 @@ kubectl apply -k github.com/open-telemetry/opentelemetry-go-instrumentation/docs
 Install Jaeger UI by running:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-instrumentation/master/docs/getting-started/jaeger.yaml -n emojivoto
+kubectl apply -f jaeger.yaml -n emojivoto
 ```
 
 This command installs Jaeger as a new Deployment and an additional Service that we will use later for accessing the Jaeger UI.
@@ -50,12 +50,12 @@ In a real world application, you would probably want to send the tracing data to
 Apply the automatic instrumentation to the `emoji`, `voting`, and `web` applications by executing the following command:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-go-instrumentation/master/docs/getting-started/emojivoto-instrumented.yaml -n emojivoto
+kubectl apply -f emojivoto-instrumented.yaml -n emojivoto
 ```
 
 ## Perform actions on the target Application
 
-Now all that left to do is to perform some actions on the target application that will cause the creation of detailed distributed traces.
+Now all that's left to do is to perform some actions on the target application that will cause the creation of detailed distributed traces.
 
 Port forward to the frontend service:
 
@@ -97,13 +97,7 @@ We can get a pretty good understanding of how the leaderboard feature works by l
 - Second, The web service will loop over the received list of emojis and for every item on the list it will perform a gRPC request to the `emoji` service to get the amount of votes for the current item.
 - As you can see this happens sequentially, which is one of the reason the leaderboard endpoint takes about 150ms to complete.
 
-### Notice that we did not change any application code to get those traces, we are using the exact same containers from the emojivoto project.
-
-## Next Steps
-
-The easiest way to apply this automatic instrumentation for any application is by using a control plane such as [Odigos](https://github.com/keyval-dev/odigos).
-
-For more details visit the [Odigos website](https://odigos.io).
+**Notice that we did not change any application code to get those traces, we are using the exact same containers from the emojivoto project.**
 
 ## Cleanup
 

--- a/docs/getting-started/emojivoto-instrumented.yaml
+++ b/docs/getting-started/emojivoto-instrumented.yaml
@@ -22,17 +22,6 @@ spec:
       serviceAccountName: emoji
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 0
-      initContainers:
-        - name: copy-launcher
-          image: keyval/launcher:v0.1
-          command:
-            - cp
-            - -a
-            - /kv-launcher/.
-            - /odigos-launcher/
-          volumeMounts:
-            - name: launcherdir
-              mountPath: /odigos-launcher
       containers:
         - env:
             - name: GRPC_PORT
@@ -41,12 +30,6 @@ spec:
               value: "8801"
           image: docker.l5d.io/buoyantio/emojivoto-emoji-svc:v11
           name: emoji-svc
-          command:
-            - /odigos-launcher/launch
-            - /usr/local/bin/emojivoto-emoji-svc
-          volumeMounts:
-            - mountPath: /odigos-launcher
-              name: launcherdir
           ports:
             - containerPort: 8080
               name: grpc
@@ -56,7 +39,7 @@ spec:
             requests:
               cpu: 100m
         - name: emojivoto-emoji-instrumentation
-          image: keyval/otel-go-agent:v0.6.0
+          image: otel-go-instrumentation:v0.1
           env:
             - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-emoji-svc
@@ -70,15 +53,6 @@ spec:
               add:
                 - SYS_PTRACE
             privileged: true
-          volumeMounts:
-            - mountPath: /sys/kernel/debug
-              name: kernel-debug
-      volumes:
-        - name: launcherdir
-          emptyDir: {}
-        - name: kernel-debug
-          hostPath:
-            path: /sys/kernel/debug
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -104,17 +78,6 @@ spec:
       serviceAccountName: voting
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 0
-      initContainers:
-        - name: copy-launcher
-          image: keyval/launcher:v0.1
-          command:
-            - cp
-            - -a
-            - /kv-launcher/.
-            - /odigos-launcher/
-          volumeMounts:
-            - name: launcherdir
-              mountPath: /odigos-launcher
       containers:
         - env:
             - name: GRPC_PORT
@@ -123,12 +86,6 @@ spec:
               value: "8801"
           image: docker.l5d.io/buoyantio/emojivoto-voting-svc:v11
           name: voting-svc
-          command:
-            - /odigos-launcher/launch
-            - /usr/local/bin/emojivoto-voting-svc
-          volumeMounts:
-            - mountPath: /odigos-launcher
-              name: launcherdir
           ports:
             - containerPort: 8080
               name: grpc
@@ -138,7 +95,7 @@ spec:
             requests:
               cpu: 100m
         - name: emojivoto-voting-instrumentation
-          image: keyval/otel-go-agent:v0.6.0
+          image: otel-go-instrumentation:v0.1
           env:
             - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-voting-svc
@@ -152,15 +109,6 @@ spec:
               add:
                 - SYS_PTRACE
             privileged: true
-          volumeMounts:
-            - mountPath: /sys/kernel/debug
-              name: kernel-debug
-      volumes:
-        - name: launcherdir
-          emptyDir: {}
-        - name: kernel-debug
-          hostPath:
-            path: /sys/kernel/debug
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -186,17 +134,6 @@ spec:
       serviceAccountName: web
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 0
-      initContainers:
-        - name: copy-launcher
-          image: keyval/launcher:v0.1
-          command:
-            - cp
-            - -a
-            - /kv-launcher/.
-            - /odigos-launcher/
-          volumeMounts:
-            - name: launcherdir
-              mountPath: /odigos-launcher
       containers:
         - env:
             - name: WEB_PORT
@@ -209,12 +146,6 @@ spec:
               value: dist/index_bundle.js
           image: docker.l5d.io/buoyantio/emojivoto-web:v11
           name: web-svc
-          command:
-            - /odigos-launcher/launch
-            - /usr/local/bin/emojivoto-web
-          volumeMounts:
-            - mountPath: /odigos-launcher
-              name: launcherdir
           ports:
             - containerPort: 8080
               name: http
@@ -222,7 +153,7 @@ spec:
             requests:
               cpu: 100m
         - name: emojivoto-web-instrumentation
-          image: keyval/otel-go-agent:v0.6.0
+          image: otel-go-instrumentation:v0.1
           env:
             - name: OTEL_GO_AUTO_TARGET_EXE
               value: /usr/local/bin/emojivoto-web
@@ -236,12 +167,3 @@ spec:
               add:
                 - SYS_PTRACE
             privileged: true
-          volumeMounts:
-            - mountPath: /sys/kernel/debug
-              name: kernel-debug
-      volumes:
-        - name: launcherdir
-          emptyDir: {}
-        - name: kernel-debug
-          hostPath:
-            path: /sys/kernel/debug


### PR DESCRIPTION
This updates the emojivoto example in the getting-started docs:

- Remove launcher, which is no longer needed after #40 
- Update instrumentation to use `otel-go-instrumentation` image instead of `keyval/otel-go-agent` 
- Simplify paths to kubernetes manifests (use relative instead of absolute)

Note: This instruments gRPC but has the issue referenced in #78 . Also, the docker image has not yet been published so this currently requires a local build. Since those are already known issues, I think this is worth merging in anyway - I'm not sure how helpful it is to show an example of the instrumentation if it's not actually instrumentation from this library.

{"level":"error","ts":1682967887.022351,"caller":"instrumentors/runner.go:88","msg":"error while loading instrumentors, cleaning up","name":"google.golang.org/grpc","error":"field UprobeHttp2ClientCreateHeaderFields: program uprobe_Http2Client_CreateHeaderFields: load program: permission denied: 912: (73) *(u8 *)(r10 -196) = r7: 913: (79) r2 = *(u64 *)( (truncated, 1185 line(s) omitted)","stacktrace":"go.opentelemetry.io/auto/pkg/instrumentors.(*Manager).load\n\t/app/pkg/instrumentors/runner.go:88\ngo.opentelemetry.io/auto/pkg/instrumentors.(*Manager).Run\n\t/app/pkg/instrumentors/runner.go:36\nmain.main\n\t/app/cli/main.go:86\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}