### PR TITLE
[chore] Update offsets workflow to run daily

### DIFF
--- a/.github/workflows/offsets.yml
+++ b/.github/workflows/offsets.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * *'
 
 jobs:
   updateOffsets:


### PR DESCRIPTION
The offsets workflow creates an update PR if required, but is only scheduled to run once per week. If a new go version is released before an offsets PR is merged, all open PRs will fail.

This PR updates the workflow to run daily instead to help catch updates faster.