### PR TITLE
Release v0.2.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.2.0-alpha] - 2023-05-03
+
 ### Added
 
 - Add [gin-gonic/gin](https://github.com/gin-gonic/gin) instrumentation. ([#100](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/100))
@@ -25,5 +27,6 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.1.0-alpha...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.2.0-alpha...HEAD
+[v0.2.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.2.0-alpha
 [v0.1.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.1.0-alpha

--- a/test/e2e/gin/traces.json
+++ b/test/e2e/gin/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.1.0-alpha"
+              "stringValue": "v0.2.0-alpha"
             }
           },
           {

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.1.0-alpha"
+              "stringValue": "v0.2.0-alpha"
             }
           },
           {

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.1.0-alpha"
+              "stringValue": "v0.2.0-alpha"
             }
           },
           {

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.1.0-alpha"
+	return "v0.2.0-alpha"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -18,6 +18,7 @@ module-sets:
     modules:
       - go.opentelemetry.io/auto
       - go.opentelemetry.io/auto/offsets-tracker
+      - go.opentelemetry.io/auto/test/e2e/gin
       - go.opentelemetry.io/auto/test/e2e/gorillamux
       - go.opentelemetry.io/auto/test/e2e/nethttp
 excluded-modules:

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   alpha:
-    version: v0.1.0-alpha
+    version: v0.2.0-alpha
     modules:
       - go.opentelemetry.io/auto
       - go.opentelemetry.io/auto/offsets-tracker


### PR DESCRIPTION
### Added

- Add [gin-gonic/gin](https://github.com/gin-gonic/gin) instrumentation. ([#100](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/100))
- Add ARM64 support. ([#82](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/82))
- Add `OTEL_GO_AUTO_SHOW_VERIFIER_LOG` environment variable to control whether the verifier log is shown. ([#128](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/128))

### Changed

- Use version spans in `offsets_results.json` instead of storing each version. ([#45](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/45))
- Change `OTEL_TARGET_EXE` environment variable to `OTEL_GO_AUTO_TARGET_EXE`. ([#97](https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/97))
