### PR TITLE
update http span names to include method and route

### DIFF
--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"os"
 
@@ -193,6 +194,7 @@ func (h *Instrumentor) Run(eventsChan chan<- *events.Event) {
 func (h *Instrumentor) convertEvent(e *Event) *events.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
+	name := fmt.Sprintf("%s %s", method, path)
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    e.SpanContext.TraceID,
@@ -202,7 +204,7 @@ func (h *Instrumentor) convertEvent(e *Event) *events.Event {
 
 	return &events.Event{
 		Library:     h.LibraryName(),
-		Name:        path,
+		Name:        name,
 		Kind:        trace.SpanKindServer,
 		StartTime:   int64(e.StartTime),
 		EndTime:     int64(e.EndTime),

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"os"
 
 	"go.opentelemetry.io/auto/pkg/instrumentors/bpffs"
@@ -180,6 +181,7 @@ func (g *Instrumentor) Run(eventsChan chan<- *events.Event) {
 func (g *Instrumentor) convertEvent(e *Event) *events.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
+	name := fmt.Sprintf("%s %s", method, path)
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    e.SpanContext.TraceID,
@@ -189,7 +191,7 @@ func (g *Instrumentor) convertEvent(e *Event) *events.Event {
 
 	return &events.Event{
 		Library:     g.LibraryName(),
-		Name:        path,
+		Name:        name,
 		Kind:        trace.SpanKindServer,
 		StartTime:   int64(e.StartTime),
 		EndTime:     int64(e.EndTime),

--- a/pkg/instrumentors/bpf/net/http/server/probe.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"os"
 
 	"go.opentelemetry.io/auto/pkg/instrumentors/bpffs"
@@ -191,6 +192,7 @@ func (h *Instrumentor) Run(eventsChan chan<- *events.Event) {
 func (h *Instrumentor) convertEvent(e *Event) *events.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
+	name := fmt.Sprintf("%s %s", method, path)
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    e.SpanContext.TraceID,
@@ -200,7 +202,7 @@ func (h *Instrumentor) convertEvent(e *Event) *events.Event {
 
 	return &events.Event{
 		Library:     h.LibraryName(),
-		Name:        path,
+		Name:        name,
 		Kind:        trace.SpanKindServer,
 		StartTime:   int64(e.StartTime),
 		EndTime:     int64(e.EndTime),

--- a/test/e2e/gin/traces.json
+++ b/test/e2e/gin/traces.json
@@ -45,7 +45,7 @@
                 }
               ],
               "kind": 2,
-              "name": "/hello-gin",
+              "name": "GET /hello-gin",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -45,7 +45,7 @@
                 }
               ],
               "kind": 2,
-              "name": "/users/foo",
+              "name": "GET /users/foo",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -45,7 +45,7 @@
                 }
               ],
               "kind": 2,
-              "name": "/hello",
+              "name": "GET /hello",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},


### PR DESCRIPTION
Current [semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#name) state "HTTP server span names SHOULD be `{http.method} {http.route}`".

This PR adjusts http span names from `{http.route}` to `{http.method} {http.route}`. Also updated are the `traces.json` files to show the new name.