### PR TITLE
Fix gRPC instrumentation on recent kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Fix gRPC instrumentation on recent kernels ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Fixed
 
-- Fix gRPC instrumentation on recent kernels ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))
+- Fix gRPC instrumentation memory access issue on newer kernels. ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))
 
 ## [v0.2.0-alpha] - 2023-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Changed
+
+- Fix gRPC instrumentation on recent kernels ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))
+
 ## [v0.2.0-alpha] - 2023-05-03
 
 ### Added

--- a/include/alloc.h
+++ b/include/alloc.h
@@ -15,6 +15,7 @@
 #include "bpf_helpers.h"
 
 #define MAX_ENTRIES 50
+#define MAX_BUFFER_SIZE 1024
 
 // Injected in init
 volatile const u32 total_cpus;
@@ -65,6 +66,22 @@ static __always_inline u64 get_area_end(u64 start)
     }
 }
 
+static __always_inline s32 bound_number(s32 num, s32 min, s32 max)
+{
+    if (num < min)
+    {
+        return min;
+    }
+    else if (num > max)
+    {
+        return max;
+    }
+    else
+    {
+        return num;
+    }
+}
+
 static __always_inline void *write_target_data(void *data, s32 size)
 {
     if (!data || data == NULL)
@@ -83,6 +100,7 @@ static __always_inline void *write_target_data(void *data, s32 size)
     }
 
     void *target = (void *)start;
+    size = bound_number(size, 1, MAX_BUFFER_SIZE);
     long success = bpf_probe_write_user(target, data, size);
     if (success == 0)
     {

--- a/include/alloc.h
+++ b/include/alloc.h
@@ -16,6 +16,7 @@
 
 #define MAX_ENTRIES 50
 #define MAX_BUFFER_SIZE 1024
+#define MIN_BUFFER_SIZE 1
 
 // Injected in init
 volatile const u32 total_cpus;
@@ -76,10 +77,7 @@ static __always_inline s32 bound_number(s32 num, s32 min, s32 max)
     {
         return max;
     }
-    else
-    {
-        return num;
-    }
+    return num;
 }
 
 static __always_inline void *write_target_data(void *data, s32 size)
@@ -100,7 +98,7 @@ static __always_inline void *write_target_data(void *data, s32 size)
     }
 
     void *target = (void *)start;
-    size = bound_number(size, 1, MAX_BUFFER_SIZE);
+    size = bound_number(size, MIN_BUFFER_SIZE, MAX_BUFFER_SIZE);
     long success = bpf_probe_write_user(target, data, size);
     if (success == 0)
     {

--- a/include/go_types.h
+++ b/include/go_types.h
@@ -16,6 +16,7 @@
 #include "bpf_helpers.h"
 
 #define MAX_REALLOCATION 400
+#define MAX_DATA_SIZE 400
 
 struct go_string
 {
@@ -72,6 +73,11 @@ static __always_inline void append_item_to_slice(struct go_slice *slice, void *n
     else
     {
         // No room on current array - copy to new one of size item_size * (len + 1)
+        if (slice->len > MAX_DATA_SIZE || slice->len < 1)
+        {
+            return;
+        }
+
         s32 alloc_size = item_size * slice->len;
         s32 bounded_alloc_size = alloc_size > MAX_REALLOCATION ? MAX_REALLOCATION : (alloc_size < 1 ? 1 : alloc_size);
 
@@ -86,7 +92,15 @@ static __always_inline void append_item_to_slice(struct go_slice *slice, void *n
         // Append to buffer
         bpf_probe_read_user(map_buff, bounded_alloc_size, slice->array);
         bpf_probe_read(map_buff + bounded_alloc_size, item_size, new_item);
-        void *new_array = write_target_data(map_buff, bounded_alloc_size + item_size);
+
+        // Copy buffer to userspace
+        u32 new_array_size = bounded_alloc_size + item_size;
+        if (new_array_size > MAX_DATA_SIZE || new_array_size < 1)
+        {
+            return;
+        }
+
+        void *new_array = write_target_data(map_buff, new_array_size);
 
         // Update array
         slice->array = new_array;

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
@@ -129,7 +129,7 @@ func (g *Instrumentor) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	up, err := ctx.Executable.Uprobe("", g.bpfObjects.UprobeServerHandleStream, &link.UprobeOptions{
-		Offset: offset,
+		Address: offset,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
In recent kernel versions, the eBPF verifier checks that a valid number of bytes (positive and not overflow) are being written/read from memory.
This PR adds additional bound checks so gRPC instrumentation now passes verification.

Tested on Ubuntu 20.02, x86, running in DigitalOcean.

- Closes https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/78
- Closes https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/141