### PR TITLE
[chore] Add DockerHub to release destinations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,16 @@ jobs:
     permissions:
       contents: read
       packages: write
-
+    env:
+      IMAGE_NAME: autoinstrumentation-go
     steps:
       - uses: actions/checkout@v3.5.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0
@@ -30,7 +37,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.4.0
         with:
-          images: ghcr.io/${{ github.repository }}/autoinstrumentation-go
+          images: |
+            otel/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push
         uses: docker/build-push-action@v4.0.0


### PR DESCRIPTION
Adds back dockerhub to release destinations.

Essentially a revert of https://github.com/open-telemetry/opentelemetry-go-instrumentation/commit/7f47920e1af42a577701f533a5b0bf6d3846cd8e.

See https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/66#issuecomment-1540938569 for additional detals