### PR TITLE
Release v0.2.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
-## [v0.3.0-alpha] - 2023-05-15
+## [v0.2.1-alpha] - 2023-05-15
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Changed
 
-- Only pull docker image if not present for the emojivoto example. ([#149](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/149))
 - Update HTTP span names to include method and route to match semantic conventions. ([#143](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/143))
 
 ## [v0.2.0-alpha] - 2023-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.3.0-alpha] - 2023-05-15
+
 ### Fixed
 
 - Fix gRPC instrumentation memory access issue on newer kernels. ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Changed
 
 - Update HTTP span names to include method and route to match semantic conventions. ([#143](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/143))
+- Add DockerHub to release destinations. ([#152](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/152))
 
 ## [v0.2.0-alpha] - 2023-05-03
 

--- a/test/e2e/gin/traces.json
+++ b/test/e2e/gin/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.2.0-alpha"
+              "stringValue": "v0.3.0-alpha"
             }
           },
           {

--- a/test/e2e/gin/traces.json
+++ b/test/e2e/gin/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.3.0-alpha"
+              "stringValue": "v0.2.1-alpha"
             }
           },
           {

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.2.0-alpha"
+              "stringValue": "v0.3.0-alpha"
             }
           },
           {

--- a/test/e2e/gorillamux/traces.json
+++ b/test/e2e/gorillamux/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.3.0-alpha"
+              "stringValue": "v0.2.1-alpha"
             }
           },
           {

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.2.0-alpha"
+              "stringValue": "v0.3.0-alpha"
             }
           },
           {

--- a/test/e2e/nethttp/traces.json
+++ b/test/e2e/nethttp/traces.json
@@ -12,7 +12,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.3.0-alpha"
+              "stringValue": "v0.2.1-alpha"
             }
           },
           {

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.3.0-alpha"
+	return "v0.2.1-alpha"
 }

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.2.0-alpha"
+	return "v0.3.0-alpha"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   alpha:
-    version: v0.2.0-alpha
+    version: v0.3.0-alpha
     modules:
       - go.opentelemetry.io/auto
       - go.opentelemetry.io/auto/offsets-tracker

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   alpha:
-    version: v0.3.0-alpha
+    version: v0.2.1-alpha
     modules:
       - go.opentelemetry.io/auto
       - go.opentelemetry.io/auto/offsets-tracker


### PR DESCRIPTION
### Fixed

- Fix gRPC instrumentation memory access issue on newer kernels. ([#150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/150))
- Fix missing spans in gorillamux instrumentation. ([#86](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/86))

### Changed

- Update HTTP span names to include method and route to match semantic conventions. ([#143](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/143))
