### PR TITLE
Upgrade semconv to v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Changed
 
-- Upgrade OpenTelemetry semantic conventions to v1.18.0. ([#TBD](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/TBD))
+- Upgrade OpenTelemetry semantic conventions to v1.18.0. ([#162](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/162))
 
 ## [v0.2.1-alpha] - 2023-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade OpenTelemetry semantic conventions to v1.18.0. ([#TBD](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/TBD))
+
 ## [v0.2.1-alpha] - 2023-05-15
 
 ### Fixed

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
 	"go.opentelemetry.io/auto/pkg/log"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
 	"go.opentelemetry.io/auto/pkg/log"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
 	"go.opentelemetry.io/auto/pkg/log"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -201,7 +201,6 @@ func (g *Instrumentor) convertEvent(e *Event) *events.Event {
 
 	attrs = append(attrs, semconv.RPCSystemKey.String("grpc"),
 		semconv.RPCServiceKey.String(method),
-		semconv.NetPeerIPKey.String(target),
 		semconv.NetPeerNameKey.String(target))
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
@@ -33,7 +33,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
 	"go.opentelemetry.io/auto/pkg/log"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/pkg/instrumentors/bpf/net/http/server/probe.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
 	"go.opentelemetry.io/auto/pkg/log"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/pkg/opentelemetry/controller.go
+++ b/pkg/opentelemetry/controller.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
Remove use of deprecated "net.peer.ip" in gRPC in favor of the already include "net.peer.name".