### PR TITLE
Fix dice randint range in the example

### DIFF
--- a/examples/rolldice/main.go
+++ b/examples/rolldice/main.go
@@ -37,7 +37,7 @@ func NewServer() *Server {
 }
 
 func (s *Server) rolldice(w http.ResponseWriter, _ *http.Request) {
-	n := s.rand.Intn(6)
+	n := s.rand.Intn(6) + 1
 	logger.Info("rolldice called", zap.Int("dice", n))
 	fmt.Fprintf(w, "%v", n)
 }


### PR DESCRIPTION
In the current version the dice value will be between 0 and 5. Adding 1 to the result will reflect how dice work in the real world