### PR TITLE
Fix net/http client instrumentation

### DIFF
--- a/pkg/instrumentors/bpf/net/http/client/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/net/http/client/bpf/probe.bpf.c
@@ -197,7 +197,6 @@ int uprobe_HttpClient_Do(struct pt_regs *ctx) {
     }
 
     bpf_map_update_elem(&context_to_http_events, &goroutine, &httpReq, 0);
-    bpf_map_update_elem(&spans_in_progress, &goroutine, &httpReq.sc, 0);
 
     return 0;
 }
@@ -216,7 +215,6 @@ int uprobe_HttpClient_Do_Returns(struct pt_regs *ctx) {
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
 
     bpf_map_delete_elem(&context_to_http_events, &goroutine);
-    bpf_map_delete_elem(&spans_in_progress, &goroutine);
 
     return 0;
 }


### PR DESCRIPTION
Hi,

This PR fixes the flakiness issue described in #220 as it aligns the net/http client instrumentation so it will not update the `spans_in_progress` map similarly to how the gRPC client instrumentation is implemented.

It is worth mentioning that it will not fix the underlying issue described in my comment on #220 which means sometimes injections to header map might still occur twice due to the eBPF program being ran twice.