### PR TITLE
Use common macro for Uprobe return flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
   It now has an additional flag indicating whether it'll build a dummy app for Go stdlib packages or not. ([#256]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/256)
 - The function signature of `"go.opentelemetry.io/auto/offsets-tracker/target".New` has changed.
   It now accepts a flag to determine if the returned `Data` is from the Go stdlib or not. ([#256]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/256)
+- Use UPROBE_RETURN to declare the common uprobe return logic (finding the corresponding context, setting up end time, and sending the event via perf buffer) ([#257]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/257)
+- BASE_SPAN_PROPERTIES as common fields (start time, end time, SpanContext and ParentSpanContext) for all instrumentations events (consistent between C and Go structs). ([#257]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/257)
+- Header guards in eBPF code. ([#257]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/257)
 
 ### Fixed
 

--- a/include/alloc.h
+++ b/include/alloc.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _ALLOC_H_
+#define _ALLOC_H_
+
 #include "bpf_helpers.h"
 
 #define MAX_ENTRIES 50
@@ -119,3 +122,5 @@ static __always_inline void *write_target_data(void *data, s32 size)
         return NULL;
     }
 }
+
+#endif

--- a/include/arguments.h
+++ b/include/arguments.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _ARGUMENTS_H_
+#define _ARGUMENTS_H_
+
 #include "common.h"
 #include "bpf_tracing.h"
 #include "bpf_helpers.h"
@@ -81,3 +84,5 @@ static __always_inline void *get_consistent_key(struct pt_regs *ctx, void *conte
     bpf_probe_read(&ctx_ptr, sizeof(ctx_ptr), contextContext);
     return ctx_ptr;
 }
+
+#endif

--- a/include/go_context.h
+++ b/include/go_context.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _GO_CONTEXT_H_
+#define _GO_CONTEXT_H_
+
 #include "bpf_helpers.h"
 
 #define MAX_DISTANCE 10
@@ -84,3 +87,5 @@ static __always_inline void stop_tracking_span(struct span_context *sc) {
     bpf_map_delete_elem(&tracked_spans, &ctx);
     bpf_map_delete_elem(&tracked_spans_by_sc, sc);
 }
+
+#endif

--- a/include/go_types.h
+++ b/include/go_types.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _GO_TYPES_H
+#define _GO_TYPES_H
+
 #include "alloc.h"
 #include "bpf_helpers.h"
 
@@ -122,3 +125,5 @@ static __always_inline void append_item_to_slice(struct go_slice *slice, void *n
     slice->len++;
     long success = bpf_probe_write_user(slice_user_ptr->len, &slice->len, sizeof(slice->len));
 }
+
+#endif

--- a/include/span_context.h
+++ b/include/span_context.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _SPAN_CONTEXT_H_
+#define _SPAN_CONTEXT_H_
+
 #include "utils.h"
 
 #define SPAN_CONTEXT_STRING_SIZE 55
@@ -63,3 +66,5 @@ static __always_inline void w3c_string_to_span_context(char *str, struct span_co
     hex_string_to_bytes(str + trace_id_start_pos, TRACE_ID_STRING_SIZE, ctx->TraceID);
     hex_string_to_bytes(str + span_id_start_pod, SPAN_ID_STRING_SIZE, ctx->SpanID);
 }
+
+#endif

--- a/include/uprobe.h
+++ b/include/uprobe.h
@@ -30,18 +30,16 @@
 // 5. Delete the span from the uprobe_context_map
 // 6. Delete the span from the global active spans map
 #define UPROBE_RETURN(name, event_type, ctx_struct_pos, ctx_struct_offset, uprobe_context_map, events_map) \
-SEC("uprobe/##name##")                                                                   \
-int uprobe_##name##_Returns(struct pt_regs *ctx) {                                       \
-    void *req_ptr = get_argument(ctx, ctx_struct_pos);                                 \
-                                                                                       \
-    void *key = get_consistent_key(ctx, (void *)(req_ptr + ctx_struct_offset));        \
-                                                                                       \
-    void *req_ptr_map = bpf_map_lookup_elem(&uprobe_context_map, &key);                \
-    event_type tmpReq = {};                                                            \
-    bpf_probe_read(&tmpReq, sizeof(tmpReq), req_ptr_map);                              \
-    tmpReq.end_time = bpf_ktime_get_ns();                                              \
-    bpf_perf_event_output(ctx, &events_map, BPF_F_CURRENT_CPU, &tmpReq, sizeof(tmpReq));\
-    bpf_map_delete_elem(&uprobe_context_map, &key);                                    \
-    stop_tracking_span(&tmpReq.sc);                                                    \
-    return 0;                                                                           \
+SEC("uprobe/##name##")                                                                                     \
+int uprobe_##name##_Returns(struct pt_regs *ctx) {                                                         \
+    void *req_ptr = get_argument(ctx, ctx_struct_pos);                                                     \
+    void *key = get_consistent_key(ctx, (void *)(req_ptr + ctx_struct_offset));                            \
+    void *req_ptr_map = bpf_map_lookup_elem(&uprobe_context_map, &key);                                    \
+    event_type tmpReq = {};                                                                                \
+    bpf_probe_read(&tmpReq, sizeof(tmpReq), req_ptr_map);                                                  \
+    tmpReq.end_time = bpf_ktime_get_ns();                                                                  \
+    bpf_perf_event_output(ctx, &events_map, BPF_F_CURRENT_CPU, &tmpReq, sizeof(tmpReq));                   \
+    bpf_map_delete_elem(&uprobe_context_map, &key);                                                        \
+    stop_tracking_span(&tmpReq.sc);                                                                        \
+    return 0;                                                                                              \
 }

--- a/include/uprobe.h
+++ b/include/uprobe.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef _UPROBE_H_
+#define _UPROBE_H_
+
 #include "common.h"
 #include "span_context.h"
 #include "go_context.h"
@@ -43,3 +46,5 @@ int uprobe_##name##_Returns(struct pt_regs *ctx) {                              
     stop_tracking_span(&tmpReq.sc);                                                                        \
     return 0;                                                                                              \
 }
+
+#endif

--- a/include/uprobe.h
+++ b/include/uprobe.h
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common.h"
+#include "span_context.h"
+#include "go_context.h"
+
+#define BASE_SPAN_PROPERTIES \
+    u64 start_time;          \
+    u64 end_time;            \
+    struct span_context sc;  \
+    struct span_context psc; 
+
+// Common flow for uprobe return:
+// 1. Find consistend key for the current uprobe context
+// 2. Use the key to lookup for the uprobe context in the uprobe_context_map
+// 3. Update the end time of the found span
+// 4. Submit the constructed event to the agent code using perf buffer events_map
+// 5. Delete the span from the uprobe_context_map
+// 6. Delete the span from the global active spans map
+#define UPROBE_RETURN(name, event_type, ctx_struct_pos, ctx_struct_offset, uprobe_context_map, events_map) \
+SEC("uprobe/##name##")                                                                   \
+int uprobe_##name##_Returns(struct pt_regs *ctx) {                                       \
+    void *req_ptr = get_argument(ctx, ctx_struct_pos);                                 \
+                                                                                       \
+    void *key = get_consistent_key(ctx, (void *)(req_ptr + ctx_struct_offset));        \
+                                                                                       \
+    void *req_ptr_map = bpf_map_lookup_elem(&uprobe_context_map, &key);                \
+    event_type tmpReq = {};                                                            \
+    bpf_probe_read(&tmpReq, sizeof(tmpReq), req_ptr_map);                              \
+    tmpReq.end_time = bpf_ktime_get_ns();                                              \
+    bpf_perf_event_output(ctx, &events_map, BPF_F_CURRENT_CPU, &tmpReq, sizeof(tmpReq));\
+    bpf_map_delete_elem(&uprobe_context_map, &key);                                    \
+    stop_tracking_span(&tmpReq.sc);                                                    \
+    return 0;                                                                           \
+}

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf/probe.bpf.c
@@ -15,6 +15,7 @@
 #include "arguments.h"
 #include "span_context.h"
 #include "go_context.h"
+#include "uprobe.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -23,11 +24,9 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 #define MAX_CONCURRENT 50
 
 struct http_request_t {
-    u64 start_time;
-    u64 end_time;
+    BASE_SPAN_PROPERTIES
     char method[METHOD_MAX_LEN];
     char path[PATH_MAX_LEN];
-    struct span_context sc;
 };
 
 struct {
@@ -90,20 +89,4 @@ int uprobe_GinEngine_ServeHTTP(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("uprobe/GinEngine_ServeHTTP")
-int uprobe_GinEngine_ServeHTTP_Returns(struct pt_regs *ctx) {
-    u64 request_pos = 4;
-    void *req_ptr = get_argument(ctx, request_pos);
-
-    // Get key
-    void *key = get_consistent_key(ctx, (void *)(req_ptr + ctx_ptr_pos));
-
-    void *httpReq_ptr = bpf_map_lookup_elem(&http_events, &key);
-    struct http_request_t httpReq = {};
-    bpf_probe_read(&httpReq, sizeof(httpReq), httpReq_ptr);
-    httpReq.end_time = bpf_ktime_get_ns();
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
-    bpf_map_delete_elem(&http_events, &key);
-    stop_tracking_span(&httpReq.sc);
-    return 0;
-}
+UPROBE_RETURN(GinEngine_ServeHTTP, struct http_request_t, 4, ctx_ptr_pos, http_events, events)

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf_bpfel_arm64.go
@@ -15,9 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
 	Method    [7]int8
 	Path      [100]int8
-	Sc        bpfSpanContext
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/bpf_bpfel_x86.go
@@ -15,9 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
 	Method    [7]int8
 	Path      [100]int8
-	Sc        bpfSpanContext
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
@@ -45,11 +45,9 @@ const instrumentedPkg = "github.com/gin-gonic/gin"
 // Event represents an event in the gin-gonic/gin server during an HTTP
 // request-response.
 type Event struct {
-	StartTime   uint64
-	EndTime     uint64
+	context.BaseSpanProperties
 	Method      [7]byte
 	Path        [100]byte
-	SpanContext context.EBPFSpanContext
 }
 
 // Instrumentor is the gin-gonic/gin instrumentor.

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe.go
@@ -46,8 +46,8 @@ const instrumentedPkg = "github.com/gin-gonic/gin"
 // request-response.
 type Event struct {
 	context.BaseSpanProperties
-	Method      [7]byte
-	Path        [100]byte
+	Method [7]byte
+	Path   [100]byte
 }
 
 // Instrumentor is the gin-gonic/gin instrumentor.

--- a/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe_test.go
+++ b/pkg/instrumentors/bpf/github.com/gin-gonic/gin/probe_test.go
@@ -36,13 +36,15 @@ func TestInstrumentorConvertEvent(t *testing.T) {
 
 	i := New()
 	got := i.convertEvent(&Event{
-		StartTime: uint64(start.UnixNano()),
-		EndTime:   uint64(end.UnixNano()),
+		BaseSpanProperties: context.BaseSpanProperties{
+			StartTime:   uint64(start.UnixNano()),
+			EndTime:     uint64(end.UnixNano()),
+			SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		},
 		// "GET"
 		Method: [7]byte{0x47, 0x45, 0x54},
 		// "/foo/bar"
-		Path:        [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
-		SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		Path: [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
 	})
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_arm64.go
@@ -15,9 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
 	Method    [7]int8
 	Path      [100]int8
-	Sc        bpfSpanContext
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_x86.go
@@ -15,9 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
+	Sc        bpfSpanContext
+	Psc       bpfSpanContext
 	Method    [7]int8
 	Path      [100]int8
-	Sc        bpfSpanContext
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
@@ -45,8 +45,8 @@ const instrumentedPkg = "github.com/gorilla/mux"
 // request-response.
 type Event struct {
 	context.BaseSpanProperties
-	Method      [7]byte
-	Path        [100]byte
+	Method [7]byte
+	Path   [100]byte
 }
 
 // Instrumentor is the gorilla/mux instrumentor.

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe.go
@@ -44,11 +44,9 @@ const instrumentedPkg = "github.com/gorilla/mux"
 // Event represents an event in the gorilla/mux server during an HTTP
 // request-response.
 type Event struct {
-	StartTime   uint64
-	EndTime     uint64
+	context.BaseSpanProperties
 	Method      [7]byte
 	Path        [100]byte
-	SpanContext context.EBPFSpanContext
 }
 
 // Instrumentor is the gorilla/mux instrumentor.

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/probe_test.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/probe_test.go
@@ -36,13 +36,15 @@ func TestInstrumentorConvertEvent(t *testing.T) {
 
 	i := New()
 	got := i.convertEvent(&Event{
-		StartTime: uint64(start.UnixNano()),
-		EndTime:   uint64(end.UnixNano()),
+		BaseSpanProperties: context.BaseSpanProperties{
+			StartTime:   uint64(start.UnixNano()),
+			EndTime:     uint64(end.UnixNano()),
+			SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		},
 		// "GET"
 		Method: [7]byte{0x47, 0x45, 0x54},
 		// "/foo/bar"
-		Path:        [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
-		SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		Path: [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
 	})
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_arm64.go
@@ -15,10 +15,10 @@ import (
 type bpfGrpcRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [50]int8
-	Target    [50]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [50]int8
+	Target    [50]int8
 	_         [4]byte
 }
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_x86.go
@@ -15,10 +15,10 @@ import (
 type bpfGrpcRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [50]int8
-	Target    [50]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [50]int8
+	Target    [50]int8
 	_         [4]byte
 }
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/probe.go
@@ -43,12 +43,9 @@ import (
 
 // Event represents an event in the gRPC client during a gRPC request.
 type Event struct {
-	StartTime         uint64
-	EndTime           uint64
-	Method            [50]byte
-	Target            [50]byte
-	SpanContext       context.EBPFSpanContext
-	ParentSpanContext context.EBPFSpanContext
+	context.BaseSpanProperties
+	Method [50]byte
+	Target [50]byte
 }
 
 // Instrumentor is the gRPC client instrumentor.

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
@@ -16,6 +16,7 @@
 #include "go_types.h"
 #include "span_context.h"
 #include "go_context.h"
+#include "uprobe.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -28,11 +29,8 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 struct grpc_request_t
 {
-    u64 start_time;
-    u64 end_time;
+    BASE_SPAN_PROPERTIES
     char method[MAX_SIZE];
-    struct span_context sc;
-    struct span_context psc;
 };
 
 struct
@@ -116,23 +114,7 @@ int uprobe_server_handleStream(struct pt_regs *ctx)
     return 0;
 }
 
-SEC("uprobe/server_handleStream")
-int uprobe_server_handleStream_Returns(struct pt_regs *ctx)
-{
-    u64 stream_pos = 4;
-    void *stream_ptr = get_argument(ctx, stream_pos);
-    void *key = get_consistent_key(ctx, (void *)(stream_ptr + stream_ctx_pos));
-
-    void *grpcReq_ptr = bpf_map_lookup_elem(&grpc_events, &key);
-    struct grpc_request_t grpcReq = {};
-    bpf_probe_read(&grpcReq, sizeof(grpcReq), grpcReq_ptr);
-
-    grpcReq.end_time = bpf_ktime_get_ns();
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &grpcReq, sizeof(grpcReq));
-    bpf_map_delete_elem(&grpc_events, &key);
-    stop_tracking_span(&grpcReq.sc);
-    return 0;
-}
+UPROBE_RETURN(server_handleStream, struct grpc_request_t, 4, stream_ctx_pos, grpc_events, events)
 
 // func (d *decodeState) decodeHeader(frame *http2.MetaHeadersFrame) error
 SEC("uprobe/decodeState_decodeHeader")

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_arm64.go
@@ -15,9 +15,9 @@ import (
 type bpfGrpcRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [100]int8
 	_         [4]byte
 }
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_x86.go
@@ -15,9 +15,9 @@ import (
 type bpfGrpcRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [100]int8
 	_         [4]byte
 }
 

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/probe.go
@@ -41,11 +41,8 @@ import (
 
 // Event represents an event in the gRPC server during a gRPC request.
 type Event struct {
-	StartTime         uint64
-	EndTime           uint64
-	Method            [100]byte
-	SpanContext       context.EBPFSpanContext
-	ParentSpanContext context.EBPFSpanContext
+	context.BaseSpanProperties
+	Method [100]byte
 }
 
 // Instrumentor is the gRPC server instrumentor.

--- a/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_arm64.go
@@ -15,10 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [10]int8
-	Path      [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [10]int8
+	Path      [100]int8
 	_         [2]byte
 }
 

--- a/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_x86.go
@@ -15,10 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [10]int8
-	Path      [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [10]int8
+	Path      [100]int8
 	_         [2]byte
 }
 

--- a/pkg/instrumentors/bpf/net/http/client/probe.go
+++ b/pkg/instrumentors/bpf/net/http/client/probe.go
@@ -42,8 +42,8 @@ import (
 // request-response.
 type Event struct {
 	context.BaseSpanProperties
-	Method            [10]byte
-	Path              [100]byte
+	Method [10]byte
+	Path   [100]byte
 }
 
 // Instrumentor is the net/http instrumentor.

--- a/pkg/instrumentors/bpf/net/http/client/probe.go
+++ b/pkg/instrumentors/bpf/net/http/client/probe.go
@@ -41,12 +41,9 @@ import (
 // Event represents an event in an HTTP server during an HTTP
 // request-response.
 type Event struct {
-	StartTime         uint64
-	EndTime           uint64
+	context.BaseSpanProperties
 	Method            [10]byte
 	Path              [100]byte
-	SpanContext       context.EBPFSpanContext
-	ParentSpanContext context.EBPFSpanContext
 }
 
 // Instrumentor is the net/http instrumentor.

--- a/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/net/http/server/bpf/probe.bpf.c
@@ -16,6 +16,7 @@
 #include "span_context.h"
 #include "go_context.h"
 #include "go_types.h"
+#include "uprobe.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -28,12 +29,9 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 struct http_request_t
 {
-    u64 start_time;
-    u64 end_time;
+    BASE_SPAN_PROPERTIES
     char method[METHOD_MAX_LEN];
     char path[PATH_MAX_LEN];
-    struct span_context sc;
-    struct span_context psc;
 };
 
 struct
@@ -224,19 +222,4 @@ int uprobe_ServerMux_ServeHTTP(struct pt_regs *ctx)
     return 0;
 }
 
-SEC("uprobe/ServerMux_ServeHTTP")
-int uprobe_ServerMux_ServeHTTP_Returns(struct pt_regs *ctx)
-{
-    u64 request_pos = 4;
-    void *req_ptr = get_argument(ctx, request_pos);
-    void *key = get_consistent_key(ctx, (void *)(req_ptr + ctx_ptr_pos));
-
-    void *httpReq_ptr = bpf_map_lookup_elem(&http_events, &key);
-    struct http_request_t httpReq = {};
-    bpf_probe_read(&httpReq, sizeof(httpReq), httpReq_ptr);
-    httpReq.end_time = bpf_ktime_get_ns();
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &httpReq, sizeof(httpReq));
-    bpf_map_delete_elem(&http_events, &key);
-    stop_tracking_span(&httpReq.sc);
-    return 0;
-}
+UPROBE_RETURN(ServerMux_ServeHTTP, struct http_request_t, 4, ctx_ptr_pos, http_events, events)

--- a/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_arm64.go
@@ -15,10 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [7]int8
-	Path      [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [7]int8
+	Path      [100]int8
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_x86.go
@@ -15,10 +15,10 @@ import (
 type bpfHttpRequestT struct {
 	StartTime uint64
 	EndTime   uint64
-	Method    [7]int8
-	Path      [100]int8
 	Sc        bpfSpanContext
 	Psc       bpfSpanContext
+	Method    [7]int8
+	Path      [100]int8
 	_         [5]byte
 }
 

--- a/pkg/instrumentors/bpf/net/http/server/probe.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe.go
@@ -45,8 +45,8 @@ const instrumentedPkg = "net/http"
 // request-response.
 type Event struct {
 	context.BaseSpanProperties
-	Method            [7]byte
-	Path              [100]byte
+	Method [7]byte
+	Path   [100]byte
 }
 
 // Instrumentor is the net/http instrumentor.

--- a/pkg/instrumentors/bpf/net/http/server/probe.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe.go
@@ -44,12 +44,9 @@ const instrumentedPkg = "net/http"
 // Event represents an event in an HTTP server during an HTTP
 // request-response.
 type Event struct {
-	StartTime         uint64
-	EndTime           uint64
+	context.BaseSpanProperties
 	Method            [7]byte
 	Path              [100]byte
-	SpanContext       context.EBPFSpanContext
-	ParentSpanContext context.EBPFSpanContext
 }
 
 // Instrumentor is the net/http instrumentor.

--- a/pkg/instrumentors/bpf/net/http/server/probe_test.go
+++ b/pkg/instrumentors/bpf/net/http/server/probe_test.go
@@ -36,13 +36,15 @@ func TestInstrumentorConvertEvent(t *testing.T) {
 
 	i := New()
 	got := i.convertEvent(&Event{
-		StartTime: uint64(start.UnixNano()),
-		EndTime:   uint64(end.UnixNano()),
+		BaseSpanProperties: context.BaseSpanProperties{
+			StartTime:   uint64(start.UnixNano()),
+			EndTime:     uint64(end.UnixNano()),
+			SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		},
 		// "GET"
 		Method: [7]byte{0x47, 0x45, 0x54},
 		// "/foo/bar"
-		Path:        [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
-		SpanContext: context.EBPFSpanContext{TraceID: traceID, SpanID: spanID},
+		Path: [100]byte{0x2f, 0x66, 0x6f, 0x6f, 0x2f, 0x62, 0x61, 0x72},
 	})
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{

--- a/pkg/instrumentors/context/span_context.go
+++ b/pkg/instrumentors/context/span_context.go
@@ -16,6 +16,13 @@ package context
 
 import "go.opentelemetry.io/otel/trace"
 
+type BaseSpanProperties struct {
+	StartTime         uint64
+	EndTime           uint64
+	SpanContext       EBPFSpanContext
+	ParentSpanContext EBPFSpanContext
+}
+
 // EBPFSpanContext is the the span context representation within the eBPF
 // instrumentation system.
 type EBPFSpanContext struct {

--- a/pkg/instrumentors/context/span_context.go
+++ b/pkg/instrumentors/context/span_context.go
@@ -16,6 +16,7 @@ package context
 
 import "go.opentelemetry.io/otel/trace"
 
+// BaseSpanProperties contains the basic attributes filled by all instrumentors.
 type BaseSpanProperties struct {
 	StartTime         uint64
 	EndTime           uint64


### PR DESCRIPTION
* Use UPROBE_RETURN to declare the common uprobe return logic (finding the corresponding context, setting up end time, and sending the event via perf buffer)
* BASE_SPAN_PROPERTIES as common fields for all instrumentations
* Header guards