### PR TITLE
Update remote mmap, avoid page faults using madvise syscall. Remove l…

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -76,6 +76,14 @@ func main() {
 		log.Logger.Error(err, "error while analyzing target process")
 		return
 	}
+
+	allocDetails, err := processAnalyzer.AllocateMemory(targetDetails)
+	if err != nil {
+		log.Logger.Error(err, "error while allocating memory")
+		return
+	}
+	targetDetails.AllocationDetails = allocDetails
+
 	log.Logger.V(0).Info("target process analysis completed", "pid", targetDetails.PID,
 		"go_version", targetDetails.GoVersion, "dependencies", targetDetails.Libraries,
 		"total_functions_found", len(targetDetails.Functions))

--- a/include/go_types.h
+++ b/include/go_types.h
@@ -54,6 +54,14 @@ struct map_bucket {
     void *overflow;
 };
 
+// In Go, interfaces are represented as a pair of pointers: a pointer to the
+// interface data, and a pointer to the interface table.
+// See: runtime.iface in https://golang.org/src/runtime/runtime2.go
+static __always_inline void *get_go_interface_instance(void *iface)
+{
+    return (void *)(iface + 8);
+}
+
 static __always_inline struct go_string write_user_go_string(char *str, u32 len)
 {
     // Copy chars to userspace

--- a/pkg/instrumentors/allocator/allocator_linux.go
+++ b/pkg/instrumentors/allocator/allocator_linux.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/auto/pkg/instrumentors/bpffs"
 	"go.opentelemetry.io/auto/pkg/instrumentors/context"
 	"go.opentelemetry.io/auto/pkg/log"
+	"go.opentelemetry.io/auto/pkg/process"
 )
 
 // Allocator handles the allocation of the BPF file-system.
@@ -44,4 +45,9 @@ func (a *Allocator) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	return nil
+}
+
+// Call bpffs cleanup.
+func (a *Allocator) Cleanup(target *process.TargetDetails) error {
+	return bpffs.Cleanup(target)
 }

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_arm64.go
@@ -76,6 +76,8 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer  *ebpf.MapSpec `ebpf:"alignment_buffer"`
+	AllocMap         *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events           *ebpf.MapSpec `ebpf:"events"`
 	HttpEvents       *ebpf.MapSpec `ebpf:"http_events"`
 	TrackedSpans     *ebpf.MapSpec `ebpf:"tracked_spans"`
@@ -101,6 +103,8 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer  *ebpf.Map `ebpf:"alignment_buffer"`
+	AllocMap         *ebpf.Map `ebpf:"alloc_map"`
 	Events           *ebpf.Map `ebpf:"events"`
 	HttpEvents       *ebpf.Map `ebpf:"http_events"`
 	TrackedSpans     *ebpf.Map `ebpf:"tracked_spans"`
@@ -109,6 +113,8 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
+		m.AllocMap,
 		m.Events,
 		m.HttpEvents,
 		m.TrackedSpans,

--- a/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/github.com/gorilla/mux/bpf_bpfel_x86.go
@@ -76,6 +76,8 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer  *ebpf.MapSpec `ebpf:"alignment_buffer"`
+	AllocMap         *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events           *ebpf.MapSpec `ebpf:"events"`
 	HttpEvents       *ebpf.MapSpec `ebpf:"http_events"`
 	TrackedSpans     *ebpf.MapSpec `ebpf:"tracked_spans"`
@@ -101,6 +103,8 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer  *ebpf.Map `ebpf:"alignment_buffer"`
+	AllocMap         *ebpf.Map `ebpf:"alloc_map"`
 	Events           *ebpf.Map `ebpf:"events"`
 	HttpEvents       *ebpf.Map `ebpf:"http_events"`
 	TrackedSpans     *ebpf.Map `ebpf:"tracked_spans"`
@@ -109,6 +113,8 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
+		m.AllocMap,
 		m.Events,
 		m.HttpEvents,
 		m.TrackedSpans,

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_arm64.go
@@ -80,6 +80,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer        *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                 *ebpf.MapSpec `ebpf:"events"`
 	GrpcEvents             *ebpf.MapSpec `ebpf:"grpc_events"`
@@ -108,6 +109,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer        *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
 	Events                 *ebpf.Map `ebpf:"events"`
 	GrpcEvents             *ebpf.Map `ebpf:"grpc_events"`
@@ -119,6 +121,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GrpcEvents,

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/bpf_bpfel_x86.go
@@ -80,6 +80,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer        *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                 *ebpf.MapSpec `ebpf:"events"`
 	GrpcEvents             *ebpf.MapSpec `ebpf:"grpc_events"`
@@ -108,6 +109,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer        *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
 	Events                 *ebpf.Map `ebpf:"events"`
 	GrpcEvents             *ebpf.Map `ebpf:"grpc_events"`
@@ -119,6 +121,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GrpcEvents,

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf/probe.bpf.c
@@ -104,8 +104,9 @@ int uprobe_server_handleStream(struct pt_regs *ctx)
     bpf_probe_read(&grpcReq.method, method_size, method_ptr);
 
     // Get key
+    void *ctx_address = get_go_interface_instance(stream_ptr + stream_ctx_pos);
     void *ctx_iface = 0;
-    bpf_probe_read(&ctx_iface, sizeof(ctx_iface), (void *)(stream_ptr + stream_ctx_pos));
+    bpf_probe_read(&ctx_iface, sizeof(ctx_iface), ctx_address);
     void *key = get_consistent_key(ctx, (void *)(stream_ptr + stream_ctx_pos));
 
     // Write event

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_arm64.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer      *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap             *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events               *ebpf.MapSpec `ebpf:"events"`
 	GrpcEvents           *ebpf.MapSpec `ebpf:"grpc_events"`
@@ -103,6 +104,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer      *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap             *ebpf.Map `ebpf:"alloc_map"`
 	Events               *ebpf.Map `ebpf:"events"`
 	GrpcEvents           *ebpf.Map `ebpf:"grpc_events"`
@@ -113,6 +115,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GrpcEvents,

--- a/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/google/golang/org/grpc/server/bpf_bpfel_x86.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer      *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap             *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events               *ebpf.MapSpec `ebpf:"events"`
 	GrpcEvents           *ebpf.MapSpec `ebpf:"grpc_events"`
@@ -103,6 +104,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer      *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap             *ebpf.Map `ebpf:"alloc_map"`
 	Events               *ebpf.Map `ebpf:"events"`
 	GrpcEvents           *ebpf.Map `ebpf:"grpc_events"`
@@ -113,6 +115,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GrpcEvents,

--- a/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_arm64.go
@@ -76,10 +76,12 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer           *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                    *ebpf.MapSpec `ebpf:"events"`
 	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpEvents                *ebpf.MapSpec `ebpf:"http_events"`
+	HttpRequestStorageMap     *ebpf.MapSpec `ebpf:"http_request_storage_map"`
 	TrackedSpans              *ebpf.MapSpec `ebpf:"tracked_spans"`
 	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
@@ -103,20 +105,24 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer           *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
 	Events                    *ebpf.Map `ebpf:"events"`
 	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpEvents                *ebpf.Map `ebpf:"http_events"`
+	HttpRequestStorageMap     *ebpf.Map `ebpf:"http_request_storage_map"`
 	TrackedSpans              *ebpf.Map `ebpf:"tracked_spans"`
 	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GolangMapbucketStorageMap,
 		m.HttpEvents,
+		m.HttpRequestStorageMap,
 		m.TrackedSpans,
 		m.TrackedSpansBySc,
 	)

--- a/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/net/http/client/bpf_bpfel_x86.go
@@ -76,10 +76,12 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer           *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                    *ebpf.MapSpec `ebpf:"events"`
 	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpEvents                *ebpf.MapSpec `ebpf:"http_events"`
+	HttpRequestStorageMap     *ebpf.MapSpec `ebpf:"http_request_storage_map"`
 	TrackedSpans              *ebpf.MapSpec `ebpf:"tracked_spans"`
 	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
@@ -103,20 +105,24 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer           *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
 	Events                    *ebpf.Map `ebpf:"events"`
 	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpEvents                *ebpf.Map `ebpf:"http_events"`
+	HttpRequestStorageMap     *ebpf.Map `ebpf:"http_request_storage_map"`
 	TrackedSpans              *ebpf.Map `ebpf:"tracked_spans"`
 	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GolangMapbucketStorageMap,
 		m.HttpEvents,
+		m.HttpRequestStorageMap,
 		m.TrackedSpans,
 		m.TrackedSpansBySc,
 	)

--- a/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_arm64.go
+++ b/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_arm64.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer             *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap                    *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                      *ebpf.MapSpec `ebpf:"events"`
 	GolangMapbucketStorageMap   *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
@@ -104,6 +105,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer             *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap                    *ebpf.Map `ebpf:"alloc_map"`
 	Events                      *ebpf.Map `ebpf:"events"`
 	GolangMapbucketStorageMap   *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
@@ -115,6 +117,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GolangMapbucketStorageMap,

--- a/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_x86.go
+++ b/pkg/instrumentors/bpf/net/http/server/bpf_bpfel_x86.go
@@ -76,6 +76,7 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
+	AlignmentBuffer             *ebpf.MapSpec `ebpf:"alignment_buffer"`
 	AllocMap                    *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                      *ebpf.MapSpec `ebpf:"events"`
 	GolangMapbucketStorageMap   *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
@@ -104,6 +105,7 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
+	AlignmentBuffer             *ebpf.Map `ebpf:"alignment_buffer"`
 	AllocMap                    *ebpf.Map `ebpf:"alloc_map"`
 	Events                      *ebpf.Map `ebpf:"events"`
 	GolangMapbucketStorageMap   *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
@@ -115,6 +117,7 @@ type bpfMaps struct {
 
 func (m *bpfMaps) Close() error {
 	return _BpfClose(
+		m.AlignmentBuffer,
 		m.AllocMap,
 		m.Events,
 		m.GolangMapbucketStorageMap,

--- a/pkg/instrumentors/runner.go
+++ b/pkg/instrumentors/runner.go
@@ -47,7 +47,7 @@ func (m *Manager) Run(target *process.TargetDetails) error {
 		case <-m.done:
 			log.Logger.V(0).Info("shutting down all instrumentors due to signal")
 			m.cleanup()
-			return nil
+			return m.allocator.Cleanup(target)
 		case e := <-m.incomingEvents:
 			m.otelController.Trace(e)
 		}

--- a/pkg/instrumentors/utils/kernel.go
+++ b/pkg/instrumentors/utils/kernel.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+	"syscall"
+
+	"github.com/hashicorp/go-version"
+)
+
+// GetLinuxKernelVersion finds the kernel version using 'uname' syscall.
+func GetLinuxKernelVersion() (*version.Version, error) {
+	var utsname syscall.Utsname
+
+	if err := syscall.Uname(&utsname); err != nil {
+		return nil, err
+	}
+
+	var buf [65]byte
+	for i, v := range utsname.Release {
+		buf[i] = byte(v)
+	}
+
+	ver := string(buf[:])
+	if strings.Contains(ver, "-") {
+		ver = strings.Split(ver, "-")[0]
+	}
+
+	return version.NewVersion(ver)
+}

--- a/pkg/process/ptrace/ptrace_linux.go
+++ b/pkg/process/ptrace/ptrace_linux.go
@@ -21,11 +21,22 @@ import (
 	"strings"
 	"syscall"
 
+	"go.opentelemetry.io/auto/pkg/log"
+
+	"github.com/hashicorp/go-version"
+
+	"go.opentelemetry.io/auto/pkg/instrumentors/utils"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
 
 const waitPidErrorMessage = "waitpid ret value: %d"
+
+const (
+	MadvPopulateRead  = 0x16 // MADV_POPULATE_READ
+	MadvPopulateWrite = 0x17 // MADV_POPULATE_WRITE
+)
 
 var threadRetryLimit = 10
 
@@ -208,5 +219,23 @@ func (p *TracedProgram) Step() error {
 
 // Mmap runs mmap syscall.
 func (p *TracedProgram) Mmap(length uint64, fd uint64) (uint64, error) {
-	return p.Syscall(syscall.SYS_MMAP, 0, length, syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_EXEC, syscall.MAP_ANON|syscall.MAP_PRIVATE|syscall.MAP_POPULATE, fd, 0)
+	return p.Syscall(syscall.SYS_MMAP, 0, length, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE|syscall.MAP_POPULATE|syscall.MAP_LOCKED, fd, 0)
+}
+
+// Madvise runs madvise syscall.
+func (p *TracedProgram) Madvise(addr uint64, length uint64) error {
+	advice := uint64(syscall.MADV_WILLNEED)
+	ver, err := utils.GetLinuxKernelVersion()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	minVersion := version.Must(version.NewVersion("5.14"))
+	log.Logger.V(0).Info("Detected linux kernel version", "version", ver)
+	if ver.GreaterThanOrEqual(minVersion) {
+		advice = syscall.MADV_WILLNEED | MadvPopulateWrite | MadvPopulateRead
+	}
+
+	_, err = p.Syscall(syscall.SYS_MADVISE, addr, length, advice, 0, 0, 0)
+	return err
 }


### PR DESCRIPTION
WIP
* Update remote mmap, avoid page faults using madvise syscall
* Remove large local variable in uprobe_HttpClient_Do to avoid reaching the 512 bytes limit of eBPF