### PR TITLE
Publish retractions for accidentally pushed tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,21 @@ module go.opentelemetry.io/auto
 
 go 1.18
 
+retract (
+	v0.6.5 // Contains retractions only.
+	v0.6.4 // Published accidentally.
+	v0.6.3 // Published accidentally.
+	v0.6.2 // Published accidentally.
+	v0.6.1 // Published accidentally.
+	v0.6.0 // Published accidentally.
+	v0.5.4 // Published accidentally.
+	v0.5.3 // Published accidentally.
+	v0.5.2 // Published accidentally.
+	v0.5.1 // Published accidentally.
+	v0.5.0 // Published accidentally.
+	v0.0.0 // Published accidentally.
+)
+
 require (
 	github.com/cilium/ebpf v0.11.0
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
After this is merged, a new `v0.6.5` tag for the merge commit will be added to the repository.