### PR TITLE
fix: return error if target binary is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Changed
+
+- Fix runtime panic if OTEL_GO_AUTO_TARGET_EXE is not set. ([#339](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/339))
+
 ### Deprecated
 
 - The `go.opentelemetry.io/auto/examples/rolldice` module is deprecated.

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -16,6 +16,7 @@ package auto
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentors"
@@ -35,6 +36,12 @@ type Instrumentation struct {
 	analyzer *process.Analyzer
 	manager  *instrumentors.Manager
 }
+
+var (
+	// Error message returned when instrumentation is launched without a taget
+	// binary.
+	errUndefinedTarget = fmt.Errorf("undefined target Go binary, consider setting the %s environment variable pointing to the target binary to instrument", envTargetExeKey)
+)
 
 // NewInstrumentation returns a new [Instrumentation] configured with the
 // provided opts.
@@ -119,6 +126,9 @@ func (c instConfig) applyEnv() instConfig {
 }
 
 func (c instConfig) validate() error {
+	if c.target == nil {
+		return errUndefinedTarget
+	}
 	return c.target.Validate()
 }
 

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -38,7 +38,7 @@ type Instrumentation struct {
 }
 
 var (
-	// Error message returned when instrumentation is launched without a taget
+	// Error message returned when instrumentation is launched without a target
 	// binary.
 	errUndefinedTarget = fmt.Errorf("undefined target Go binary, consider setting the %s environment variable pointing to the target binary to instrument", envTargetExeKey)
 )


### PR DESCRIPTION
If OTEL_GO_AUTO_TARGET_EXE is not defined, a runtime panic is triggered:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x96796c]

goroutine 1 [running]:
go.opentelemetry.io/auto/internal/pkg/process.(*TargetArgs).Validate(...)