### PR TITLE
Add WithServiceName and WithPid as config options for instrumentation…

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -164,7 +164,7 @@ func WithTarget(path string) InstrumentationOption {
 	})
 }
 
-// WithServiceName returns an [InstrumentationOption] defining the service name
+// WithServiceName returns an [InstrumentationOption] defining the name of the service running.
 //
 // If multiple of these options are provided to an [Instrumentation], the last
 // one will be used.
@@ -181,12 +181,19 @@ func WithServiceName(serviceName string) InstrumentationOption {
 // WithPID returns an [InstrumentationOption] corresponding to the executable
 // used by the provided pid.
 //
-// If WithTarget is used, the one which is used last will take precedence.
+// This option conflicts with [WithTarget]. If both are used, the last one
+// passed to [Instrumentation] will take precedence and be used.
+//
+// If multiple of these options are provided to an [Instrumentation], the last
+// one will be used.
+//
+// If OTEL_GO_AUTO_TARGET_EXE is defined it will take precedence over any value
+// passed here.
 func WithPID(pid int) InstrumentationOption {
 	exeLinkPath := fmt.Sprintf("/proc/%d/exe", pid)
 	exePath, err := os.Readlink(exeLinkPath)
 	if err != nil {
-		log.Logger.Error(err, "Failed to read link for process exe")
+		log.Logger.Error(err, "Failed to read exe link for process", "pid", pid)
 		exePath = ""
 	}
 

--- a/internal/pkg/instrumentors/allocator/allocator_linux.go
+++ b/internal/pkg/instrumentors/allocator/allocator_linux.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/instrumentors/bpffs"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentors/context"
 	"go.opentelemetry.io/auto/internal/pkg/log"
+	"go.opentelemetry.io/auto/internal/pkg/process"
 )
 
 // Allocator handles the allocation of the BPF file-system.
@@ -44,4 +45,8 @@ func (a *Allocator) Load(ctx *context.InstrumentorContext) error {
 	}
 
 	return nil
+}
+
+func (a *Allocator) Clean(target *process.TargetDetails) error {
+	return bpffs.Cleanup(target)
 }

--- a/internal/pkg/instrumentors/runner.go
+++ b/internal/pkg/instrumentors/runner.go
@@ -47,11 +47,11 @@ func (m *Manager) Run(ctx context.Context, target *process.TargetDetails) error 
 		select {
 		case <-ctx.Done():
 			m.Close()
-			m.cleanup()
+			m.cleanup(target)
 			return ctx.Err()
 		case <-m.done:
 			log.Logger.V(0).Info("shutting down all instrumentors due to signal")
-			m.cleanup()
+			m.cleanup(target)
 			return nil
 		case e := <-m.incomingEvents:
 			m.otelController.Trace(e)
@@ -91,7 +91,7 @@ func (m *Manager) load(target *process.TargetDetails) error {
 		err := i.Load(ctx)
 		if err != nil {
 			log.Logger.Error(err, "error while loading instrumentors, cleaning up", "name", name)
-			m.cleanup()
+			m.cleanup(target)
 			return err
 		}
 	}
@@ -100,10 +100,17 @@ func (m *Manager) load(target *process.TargetDetails) error {
 	return nil
 }
 
-func (m *Manager) cleanup() {
+func (m *Manager) cleanup(target *process.TargetDetails) {
 	close(m.incomingEvents)
 	for _, i := range m.instrumentors {
 		i.Close()
+	}
+
+	log.Logger.V(0).Info("Cleaning bpffs")
+	err := m.allocator.Clean(target)
+
+	if err != nil {
+		log.Logger.Error(err, "Failed to clean bpffs")
 	}
 }
 

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -17,7 +17,6 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -33,10 +32,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
-)
-
-const (
-	otelServiceNameEnvVar = "OTEL_SERVICE_NAME"
 )
 
 // Information about the runtime environment for inclusion in User-Agent, e.g. "go/1.18.2 (linux/amd64)".
@@ -89,12 +84,7 @@ func (c *Controller) convertTime(t int64) time.Time {
 }
 
 // NewController returns a new initialized [Controller].
-func NewController(version string) (*Controller, error) {
-	serviceName, exists := os.LookupEnv(otelServiceNameEnvVar)
-	if !exists {
-		return nil, fmt.Errorf("%s env var must be set", otelServiceNameEnvVar)
-	}
-
+func NewController(version string, serviceName string) (*Controller, error) {
 	ctx := context.Background()
 	res, err := resource.New(ctx,
 		resource.WithAttributes(

--- a/internal/pkg/process/discover.go
+++ b/internal/pkg/process/discover.go
@@ -16,7 +16,6 @@ package process
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -97,7 +96,7 @@ func (a *Analyzer) findProcessID(target *TargetArgs) (int, error) {
 			exeName, err := os.Readlink(path.Join("/proc", dname, "exe"))
 			if err != nil {
 				// Read link may fail if target process runs not as root
-				cmdLine, err := ioutil.ReadFile(path.Join("/proc", dname, "cmdline"))
+				cmdLine, err := os.ReadFile(path.Join("/proc", dname, "cmdline"))
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
This PR add two InstrumentationOption:
* `WithServiceName` similar to `WithTarget` (with the same behavior for which environment variable is possible and will take precedence).
* `WithPID` which calls `WithTarget`.
These will be useful for https://github.com/keyval-dev/odigos/blob/main/odiglet/pkg/ebpf/director.go

In addition the `Cleanup` in bpffs was not called which resulted in garbage folders under /sys/fs/bpf not get deleted after the instrumentation is finished