### PR TITLE
Add WithServiceName config option for instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Added
+- Add WithServiceName config option for instrumentation([#353](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/353))
+
 ### Changed
 
 - Fix runtime panic if OTEL_GO_AUTO_TARGET_EXE is not set. ([#339](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/339))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ## [Unreleased]
 
 ### Added
-- Add WithServiceName config option for instrumentation([#353](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/353))
+
+- Add `WithServiceName` config option for instrumentation. ([#353](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/353))
 
 ### Changed
 

--- a/instConfig_test.go
+++ b/instConfig_test.go
@@ -15,10 +15,13 @@
 package auto
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 )
 
 func TestWithServiceName(t *testing.T) {
@@ -32,9 +35,18 @@ func TestWithServiceName(t *testing.T) {
 	c = newInstConfig([]InstrumentationOption{})
 	assert.Equal(t, serviceNameDefault, c.serviceName)
 
+	// OTEL_RESOURCE_ATTRIBUTES
+	resServiceName := "resValue"
+	err := os.Setenv(resourceAttrKey, fmt.Sprintf("key1=val1,%s=%s", string(semconv.ServiceNameKey), resServiceName))
+	if err != nil {
+		t.Error(err)
+	}
+	c = newInstConfig([]InstrumentationOption{WithServiceName((testServiceName))})
+	assert.Equal(t, resServiceName, c.serviceName)
+
 	// Add env var to take precedence
 	envServiceName := "env_serviceName"
-	err := os.Setenv(envServiceNameKey, envServiceName)
+	err = os.Setenv(envServiceNameKey, envServiceName)
 	if err != nil {
 		t.Error(err)
 	}

--- a/instConfig_test.go
+++ b/instConfig_test.go
@@ -37,7 +37,7 @@ func TestWithServiceName(t *testing.T) {
 
 	// OTEL_RESOURCE_ATTRIBUTES
 	resServiceName := "resValue"
-	err := os.Setenv(resourceAttrKey, fmt.Sprintf("key1=val1,%s=%s", string(semconv.ServiceNameKey), resServiceName))
+	err := os.Setenv(envResourceAttrKey, fmt.Sprintf("key1=val1,%s=%s", string(semconv.ServiceNameKey), resServiceName))
 	if err != nil {
 		t.Error(err)
 	}

--- a/instConfig_test.go
+++ b/instConfig_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auto
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithServiceName(t *testing.T) {
+	testServiceName := "test_serviceName"
+
+	// Use WithServiceName to config the service name
+	c := newInstConfig([]InstrumentationOption{WithServiceName((testServiceName))})
+	assert.Equal(t, testServiceName, c.serviceName)
+
+	// No service name provided - check for default value
+	c = newInstConfig([]InstrumentationOption{})
+	assert.Equal(t, serviceNameDefault, c.serviceName)
+
+	// Add env var to take precedence
+	envServiceName := "env_serviceName"
+	err := os.Setenv(envServiceNameKey, envServiceName)
+	if err != nil {
+		t.Error(err)
+	}
+	c = newInstConfig([]InstrumentationOption{WithServiceName((testServiceName))})
+	assert.Equal(t, envServiceName, c.serviceName)
+}

--- a/instConfig_test.go
+++ b/instConfig_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 func TestWithServiceName(t *testing.T) {

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -133,14 +133,16 @@ func newInstConfig(opts []InstrumentationOption) instConfig {
 }
 
 func (c instConfig) applyEnv() instConfig {
-	c = c.applyResourceAtrrEnv()
 	if v, ok := os.LookupEnv(envTargetExeKey); ok {
 		c.target = &process.TargetArgs{ExePath: v}
 	}
 	if v, ok := os.LookupEnv(envServiceNameKey); ok {
 		c.serviceName = v
-	} else if c.serviceName == "" {
-		c = c.setDefualtServiceName()
+	} else {
+		c = c.applyResourceAtrrEnv()
+		if c.serviceName == "" {
+			c = c.setDefualtServiceName()
+		}
 	}
 	return c
 }

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -154,7 +154,7 @@ func (c instConfig) setDefualtServiceName() instConfig {
 }
 
 func (c instConfig) applyResourceAtrrEnv() instConfig {
-	attrs := strings.TrimSpace(os.Getenv(resourceAttrKey))
+	attrs := strings.TrimSpace(os.Getenv(envResourceAttrKey))
 
 	if attrs == "" {
 		return c

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -25,9 +25,15 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
 
-// envTargetExeKey is the key for the environment variable value pointing to the
-// target binary to instrument.
-const envTargetExeKey = "OTEL_GO_AUTO_TARGET_EXE"
+const (
+	// envTargetExeKey is the key for the environment variable value pointing to the
+	// target binary to instrument.
+	envTargetExeKey = "OTEL_GO_AUTO_TARGET_EXE"
+	// envServiceName is the key for the envoriment variable value containing the service name.
+	envServiceNameKey = "OTEL_SERVICE_NAME"
+	// prefix for default service name if not provided.
+	serviceNameDefault = "unknown_service"
+)
 
 // Instrumentation manages and controls all OpenTelemetry Go
 // auto-instrumentation.
@@ -57,7 +63,7 @@ func NewInstrumentation(opts ...InstrumentationOption) (*Instrumentation, error)
 		return nil, err
 	}
 
-	ctrl, err := opentelemetry.NewController(Version())
+	ctrl, err := opentelemetry.NewController(Version(), c.serviceName)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +112,8 @@ type InstrumentationOption interface {
 }
 
 type instConfig struct {
-	target *process.TargetArgs
+	target      *process.TargetArgs
+	serviceName string
 }
 
 func newInstConfig(opts []InstrumentationOption) instConfig {
@@ -121,6 +128,11 @@ func newInstConfig(opts []InstrumentationOption) instConfig {
 func (c instConfig) applyEnv() instConfig {
 	if v, ok := os.LookupEnv(envTargetExeKey); ok {
 		c.target = &process.TargetArgs{ExePath: v}
+	}
+	if v, ok := os.LookupEnv(envServiceNameKey); ok {
+		c.serviceName = v
+	} else if c.serviceName == "" {
+		c.serviceName = serviceNameDefault
 	}
 	return c
 }
@@ -147,6 +159,20 @@ func (o fnOpt) apply(c instConfig) instConfig { return o(c) }
 func WithTarget(path string) InstrumentationOption {
 	return fnOpt(func(c instConfig) instConfig {
 		c.target = &process.TargetArgs{ExePath: path}
+		return c
+	})
+}
+
+// WithServiceName returns an [InstrumentationOption] defining the name of the service running.
+//
+// If multiple of these options are provided to an [Instrumentation], the last
+// one will be used.
+//
+// If OTEL_SERVICE_NAME is defined it will take precedence over any value
+// passed here.
+func WithServiceName(serviceName string) InstrumentationOption {
+	return fnOpt(func(c instConfig) instConfig {
+		c.serviceName = serviceName
 		return c
 	})
 }

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -21,11 +21,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+
 	"go.opentelemetry.io/auto/internal/pkg/instrumentors"
 	"go.opentelemetry.io/auto/internal/pkg/log"
 	"go.opentelemetry.io/auto/internal/pkg/opentelemetry"
 	"go.opentelemetry.io/auto/internal/pkg/process"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 const (

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/log"
 	"go.opentelemetry.io/auto/internal/pkg/opentelemetry"
 	"go.opentelemetry.io/auto/internal/pkg/process"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 const (
@@ -34,10 +34,11 @@ const (
 	envTargetExeKey = "OTEL_GO_AUTO_TARGET_EXE"
 	// envServiceName is the key for the envoriment variable value containing the service name.
 	envServiceNameKey = "OTEL_SERVICE_NAME"
+	// envResourceAttrKey is the key for the environment variable value containing
+	// OpenTelemetry Resource attributes.
+	envResourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES"
 	// serviceNameDefault is the default service name prefix used if a user does not provide one.
 	serviceNameDefault = "unknown_service"
-	// resourceAttrKey is the environment variable name OpenTelemetry Resource information will be read from.
-	resourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
 // Instrumentation manages and controls all OpenTelemetry Go

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -31,7 +31,7 @@ const (
 	envTargetExeKey = "OTEL_GO_AUTO_TARGET_EXE"
 	// envServiceName is the key for the envoriment variable value containing the service name.
 	envServiceNameKey = "OTEL_SERVICE_NAME"
-	// prefix for default service name if not provided.
+	// serviceNameDefault is the default service name prefix used if a user does not provide one.
 	serviceNameDefault = "unknown_service"
 )
 

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -17,7 +17,6 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -33,10 +32,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
-)
-
-const (
-	otelServiceNameEnvVar = "OTEL_SERVICE_NAME"
 )
 
 // Information about the runtime environment for inclusion in User-Agent, e.g. "go/1.18.2 (linux/amd64)".
@@ -89,12 +84,7 @@ func (c *Controller) convertTime(t int64) time.Time {
 }
 
 // NewController returns a new initialized [Controller].
-func NewController(version string) (*Controller, error) {
-	serviceName, exists := os.LookupEnv(otelServiceNameEnvVar)
-	if !exists {
-		return nil, fmt.Errorf("%s env var must be set", otelServiceNameEnvVar)
-	}
-
+func NewController(version string, serviceName string) (*Controller, error) {
 	ctx := context.Background()
 	res, err := resource.New(ctx,
 		resource.WithAttributes(


### PR DESCRIPTION
There are 3 ways to set the service name with the following precedence from high to low:
1. OTEL_SERVICE_NAME env var
2. OTEL_RESOURCE_ATTRIBUTES env var
3. WithServiceName InstrumentationOption

Default service name according to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service