### PR TITLE
Call runtime.LockOSThread() before ptrace

### DIFF
--- a/internal/pkg/process/analyze.go
+++ b/internal/pkg/process/analyze.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/hashicorp/go-version"
 
@@ -84,6 +85,8 @@ func (t *TargetDetails) GetFunctionReturns(name string) ([]uint64, error) {
 }
 
 func (a *Analyzer) remoteMmap(pid int, mapSize uint64) (uint64, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	program, err := ptrace.NewTracedProgram(pid, log.Logger)
 	if err != nil {
 		log.Logger.Error(err, "Failed to attach ptrace", "pid", pid)


### PR DESCRIPTION
From my testing, ptrace-ing the instrumented process failed every once in a while with an error "no such process"
https://github.com/golang/go/issues/43685 seems to describe the issue.
This PR should make sure the OS thread of our code is fixed durring the ptrace attachment and mmap call.