### PR TITLE
Document support of `autoexporter` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ To instrument an application running in Kubernetes, follow these steps:
 
 See the documentation for
 [`InstrumentationOption`](https://pkg.go.dev/go.opentelemetry.io/auto#InstrumentationOption)
-creation functions for information about how to configure the OpenTelemetry Go
-Automatic Instrumentation:
+factory functions for information about how to configure the OpenTelemetry Go
+Automatic Instrumentation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenTelemetry Go Automatic Instrumentation
 
+[![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/auto)](https://pkg.go.dev/go.opentelemetry.io/auto)
+
 This repository provides [OpenTelemetry] instrumentation for [Go] libraries using [eBPF].
 
 :construction: This project is currently work in progress.
@@ -129,6 +131,13 @@ To instrument an application running in Kubernetes, follow these steps:
 2. Check if the configuration [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) is present in the pod spec, if not, please add it.
 
 3. Deploy the application and the instrumentation using the manifest.
+
+### Configuration
+
+See the documentation for
+[`InstrumentationOption`](https://pkg.go.dev/go.opentelemetry.io/auto#InstrumentationOption)
+creation functions for information about how to configure the OpenTelemetry Go
+Automatic Instrumentation:
 
 ## Contributing
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,7 +42,7 @@ Environment variable configuration:
 	- OTEL_SERVICE_NAME (or OTEL_RESOURCE_ATTRIBUTES): sets the service name
 	- OTEL_TRACES_EXPORTER: sets the trace exporter
 
-The OTEL_TRACES_EXPORTER environment variable value is resolve using the
+The OTEL_TRACES_EXPORTER environment variable value is resolved using the
 autoexport (go.opentelemetry.io/contrib/exporters/autoexport) package. See that
 package's documentation for information on supported values and registration of
 custom exporters.

--- a/cli/main.go
+++ b/cli/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -30,6 +32,25 @@ import (
 	"go.opentelemetry.io/auto"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
+
+const help = `
+OpenTelemetry auto-instrumentation for Go applications using eBPF
+
+Environment variable configuration:
+
+	- OTEL_GO_AUTO_TARGET_EXE: sets the target binary
+	- OTEL_SERVICE_NAME (or OTEL_RESOURCE_ATTRIBUTES): sets the service name
+	- OTEL_TRACES_EXPORTER: sets the trace exporter
+
+The OTEL_TRACES_EXPORTER environment variable value is resolve using the
+autoexport (go.opentelemetry.io/contrib/exporters/autoexport) package. See that
+package's documentation for information on supported values and registration of
+custom exporters.
+`
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "%s", help)
+}
 
 func newLogger() logr.Logger {
 	zapLog, err := zap.NewProduction()
@@ -46,6 +67,9 @@ func newLogger() logr.Logger {
 }
 
 func main() {
+	flag.Usage = usage
+	flag.Parse()
+
 	logger := newLogger().WithName("go.opentelemetry.io/auto")
 
 	// Trap Ctrl+C and SIGTERM and call cancel on the context.

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -317,7 +317,7 @@ var lookupEnv = os.LookupEnv
 // If more than one of these options are used, the last one provided to an
 // [Instrumentation] will be used.
 //
-// The OTEL_TRACES_EXPORTER environment variable value is resolve using the
+// The OTEL_TRACES_EXPORTER environment variable value is resolved using the
 // [autoexport] package. See that package's documentation for information on
 // supported values and registration of custom exporters.
 func WithEnv() InstrumentationOption {

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -316,6 +316,10 @@ var lookupEnv = os.LookupEnv
 // and [WithServiceName] if their respective environment variable is defined.
 // If more than one of these options are used, the last one provided to an
 // [Instrumentation] will be used.
+//
+// The OTEL_TRACES_EXPORTER environment variable value is resolve using the
+// [autoexport] package. See that package's documentation for information on
+// supported values and registration of custom exporters.
 func WithEnv() InstrumentationOption {
 	return fnOpt(func(ctx context.Context, c instConfig) (instConfig, error) {
 		var err error
@@ -324,7 +328,7 @@ func WithEnv() InstrumentationOption {
 		}
 		if _, ok := lookupEnv(envTracesExportersKey); ok {
 			// Don't track the lookup value because autoexport does not provide
-			// a way to just pass the envoriment value currently. Just use
+			// a way to just pass the environment value currently. Just use
 			// NewSpanExporter which will re-read this value.
 
 			var e error


### PR DESCRIPTION
Fix #437 

- Update `WithEnv` docs to link to autoexporter pkg docs
- Add usage to CLI and include link  to autoexporter pkg docs
- Update README with link to where to find configuration info