### PR TITLE
Fix kill cmd in sample-job

### DIFF
--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -22,7 +22,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         # send SIGTERM to otel-go-instrumentation once the sample app has generated data so the job completes.
-        args: ["/sample-app/main && kill -TERM $(pidof otel-go-instrumentation)"]
+        args: ["/sample-app/main && kill --verbose --timeout 1000 TERM --timeout 1000 KILL $(pidof otel-go-instrumentation)"]
       - name: auto-instrumentation
         image: otel-go-instrumentation
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Currently, the syntax of the kill command is invalid on the linux systems the job is being run on. Update the command to use correct syntax, be verbose for debugging purposes, include 1000ms timeouts, and progress from TERM to KILL.