### PR TITLE
Move `Event` into `probe` package

### DIFF
--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -35,7 +36,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
@@ -149,7 +149,7 @@ func (h *Probe) Load(exec *link.Executable, target *process.TargetDetails) error
 }
 
 // Run runs the events processing loop.
-func (h *Probe) Run(eventsChan chan<- *events.Event) {
+func (h *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := h.eventsReader.Read()
@@ -175,7 +175,7 @@ func (h *Probe) Run(eventsChan chan<- *events.Event) {
 	}
 }
 
-func (h *Probe) convertEvent(e *Event) *events.Event {
+func (h *Probe) convertEvent(e *Event) *probe.Event {
 	query := unix.ByteSliceToString(e.Query[:])
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
@@ -197,7 +197,7 @@ func (h *Probe) convertEvent(e *Event) *events.Event {
 		pscPtr = nil
 	}
 
-	return &events.Event{
+	return &probe.Event{
 		Library:     h.LibraryName(),
 		Name:        "DB",
 		Kind:        trace.SpanKindClient,

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 )
 
 func TestProbeConvertEvent(t *testing.T) {
@@ -52,7 +52,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		SpanID:     spanID,
 		TraceFlags: trace.FlagsSampled,
 	})
-	want := &events.Event{
+	want := &probe.Event{
 		Library:     instrumentedPkg,
 		Name:        "DB",
 		Kind:        trace.SpanKindClient,

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -34,7 +35,6 @@ import (
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
@@ -157,7 +157,7 @@ func (h *Probe) registerProbes(exec *link.Executable, target *process.TargetDeta
 }
 
 // Run runs the events processing loop.
-func (h *Probe) Run(eventsChan chan<- *events.Event) {
+func (h *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := h.eventsReader.Read()
@@ -183,7 +183,7 @@ func (h *Probe) Run(eventsChan chan<- *events.Event) {
 	}
 }
 
-func (h *Probe) convertEvent(e *Event) *events.Event {
+func (h *Probe) convertEvent(e *Event) *probe.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
 
@@ -193,7 +193,7 @@ func (h *Probe) convertEvent(e *Event) *events.Event {
 		TraceFlags: trace.FlagsSampled,
 	})
 
-	return &events.Event{
+	return &probe.Event{
 		Library: h.LibraryName(),
 		// Do not include the high-cardinality path here (there is no
 		// templatized path manifest to reference, given we are instrumenting

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 )
 
 func TestProbeConvertEvent(t *testing.T) {
@@ -54,7 +54,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		SpanID:     spanID,
 		TraceFlags: trace.FlagsSampled,
 	})
-	want := &events.Event{
+	want := &probe.Event{
 		Library:     instrumentedPkg,
 		Name:        "GET",
 		Kind:        trace.SpanKindServer,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
@@ -36,7 +37,6 @@ import (
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
@@ -196,7 +196,7 @@ func (g *Probe) Load(exec *link.Executable, target *process.TargetDetails) error
 }
 
 // Run runs the events processing loop.
-func (g *Probe) Run(eventsChan chan<- *events.Event) {
+func (g *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := g.eventsReader.Read()
@@ -223,7 +223,7 @@ func (g *Probe) Run(eventsChan chan<- *events.Event) {
 }
 
 // According to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md
-func (g *Probe) convertEvent(e *Event) *events.Event {
+func (g *Probe) convertEvent(e *Event) *probe.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	target := unix.ByteSliceToString(e.Target[:])
 	var attrs []attribute.KeyValue
@@ -258,7 +258,7 @@ func (g *Probe) convertEvent(e *Event) *events.Event {
 	}
 
 	g.logger.Info("got spancontext", "trace_id", e.SpanContext.TraceID.String(), "span_id", e.SpanContext.SpanID.String())
-	return &events.Event{
+	return &probe.Event{
 		Library:           g.LibraryName(),
 		Name:              method,
 		Kind:              trace.SpanKindClient,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -34,7 +35,6 @@ import (
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
@@ -184,7 +184,7 @@ func (g *Probe) Load(exec *link.Executable, target *process.TargetDetails) error
 }
 
 // Run runs the events processing loop.
-func (g *Probe) Run(eventsChan chan<- *events.Event) {
+func (g *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := g.eventsReader.Read()
@@ -210,7 +210,7 @@ func (g *Probe) Run(eventsChan chan<- *events.Event) {
 	}
 }
 
-func (g *Probe) convertEvent(e *Event) *events.Event {
+func (g *Probe) convertEvent(e *Event) *probe.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
@@ -232,7 +232,7 @@ func (g *Probe) convertEvent(e *Event) *events.Event {
 		pscPtr = nil
 	}
 
-	return &events.Event{
+	return &probe.Event{
 		Library:   g.LibraryName(),
 		Name:      method,
 		Kind:      trace.SpanKindServer,

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
 )
@@ -148,7 +148,7 @@ func (h *Probe) Load(exec *link.Executable, target *process.TargetDetails) error
 }
 
 // Run runs the events processing loop.
-func (h *Probe) Run(eventsChan chan<- *events.Event) {
+func (h *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := h.eventsReader.Read()
@@ -174,7 +174,7 @@ func (h *Probe) Run(eventsChan chan<- *events.Event) {
 	}
 }
 
-func (h *Probe) convertEvent(e *Event) *events.Event {
+func (h *Probe) convertEvent(e *Event) *probe.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
 
@@ -197,7 +197,7 @@ func (h *Probe) convertEvent(e *Event) *events.Event {
 		pscPtr = nil
 	}
 
-	return &events.Event{
+	return &probe.Event{
 		Library:     h.LibraryName(),
 		Name:        path,
 		Kind:        trace.SpanKindClient,

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/inject"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
@@ -151,7 +151,7 @@ func (h *Probe) Load(exec *link.Executable, target *process.TargetDetails) error
 }
 
 // Run runs the events processing loop.
-func (h *Probe) Run(eventsChan chan<- *events.Event) {
+func (h *Probe) Run(eventsChan chan<- *probe.Event) {
 	var event Event
 	for {
 		record, err := h.eventsReader.Read()
@@ -177,7 +177,7 @@ func (h *Probe) Run(eventsChan chan<- *events.Event) {
 	}
 }
 
-func (h *Probe) convertEvent(e *Event) *events.Event {
+func (h *Probe) convertEvent(e *Event) *probe.Event {
 	method := unix.ByteSliceToString(e.Method[:])
 	path := unix.ByteSliceToString(e.Path[:])
 
@@ -200,7 +200,7 @@ func (h *Probe) convertEvent(e *Event) *events.Event {
 		pscPtr = nil
 	}
 
-	return &events.Event{
+	return &probe.Event{
 		Library: h.LibraryName(),
 		// Do not include the high-cardinality path here (there is no
 		// templatized path manifest to reference).

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 )
 
 func TestProbeConvertEvent(t *testing.T) {
@@ -55,7 +55,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		SpanID:     spanID,
 		TraceFlags: trace.FlagsSampled,
 	})
-	want := &events.Event{
+	want := &probe.Event{
 		Library:     instrumentedPkg,
 		Name:        "GET",
 		Kind:        trace.SpanKindServer,

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -29,7 +29,6 @@ import (
 	httpClient "go.opentelemetry.io/auto/internal/pkg/instrumentation/bpf/net/http/client"
 	httpServer "go.opentelemetry.io/auto/internal/pkg/instrumentation/bpf/net/http/server"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 	"go.opentelemetry.io/auto/internal/pkg/opentelemetry"
 	"go.opentelemetry.io/auto/internal/pkg/process"
@@ -43,7 +42,7 @@ type Manager struct {
 	logger         logr.Logger
 	probes         map[string]probe.Probe
 	done           chan bool
-	incomingEvents chan *events.Event
+	incomingEvents chan *probe.Event
 	otelController *opentelemetry.Controller
 }
 
@@ -54,7 +53,7 @@ func NewManager(logger logr.Logger, otelController *opentelemetry.Controller) (*
 		logger:         logger,
 		probes:         make(map[string]probe.Probe),
 		done:           make(chan bool, 1),
-		incomingEvents: make(chan *events.Event),
+		incomingEvents: make(chan *probe.Event),
 		otelController: otelController,
 	}
 

--- a/internal/pkg/instrumentation/probe/event.go
+++ b/internal/pkg/instrumentation/probe/event.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package events
+package probe
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -18,7 +18,6 @@ package probe
 import (
 	"github.com/cilium/ebpf/link"
 
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
 
@@ -36,7 +35,7 @@ type Probe interface {
 	Load(*link.Executable, *process.TargetDetails) error
 
 	// Run runs the events processing loop.
-	Run(eventsChan chan<- *events.Event)
+	Run(eventsChan chan<- *Event)
 
 	// Close stops the Probe.
 	Close()

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 )
 
 // Controller handles OpenTelemetry telemetry generation for events.
@@ -46,7 +46,7 @@ func (c *Controller) getTracer(libName string) trace.Tracer {
 }
 
 // Trace creates a trace span for event.
-func (c *Controller) Trace(event *events.Event) {
+func (c *Controller) Trace(event *probe.Event) {
 	c.logger.Info("got event", "attrs", event.Attributes)
 	ctx := context.Background()
 

--- a/internal/pkg/opentelemetry/id_generator.go
+++ b/internal/pkg/opentelemetry/id_generator.go
@@ -19,7 +19,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	"go.opentelemetry.io/auto/internal/pkg/instrumentation/events"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
 )
 
 type EBPFSourceIDGenerator struct{}
@@ -31,18 +31,18 @@ func NewEBPFSourceIDGenerator() *EBPFSourceIDGenerator {
 }
 
 // ContextWithEBPFEvent returns a copy of parent in which event is stored.
-func ContextWithEBPFEvent(parent context.Context, event events.Event) context.Context {
+func ContextWithEBPFEvent(parent context.Context, event probe.Event) context.Context {
 	return context.WithValue(parent, eBPFEventKey{}, event)
 }
 
 // EventFromContext returns the event within ctx if one exists.
-func EventFromContext(ctx context.Context) *events.Event {
+func EventFromContext(ctx context.Context) *probe.Event {
 	val := ctx.Value(eBPFEventKey{})
 	if val == nil {
 		return nil
 	}
 
-	event, ok := val.(events.Event)
+	event, ok := val.(probe.Event)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
The events package only contains the Event type. This is only used in the context of a probe, so move it to the probe package.