### PR TITLE
Replace `inspect.StructField` with `structfield.ID`

### DIFF
--- a/internal/tools/inspect/app.go
+++ b/internal/tools/inspect/app.go
@@ -18,10 +18,15 @@ import (
 	"context"
 	"debug/dwarf"
 	"debug/elf"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-version"
+
+	"go.opentelemetry.io/auto/internal/pkg/structfield"
 )
 
 // app holds a built Go application.
@@ -29,7 +34,7 @@ type app struct {
 	Renderer Renderer
 	Builder  *builder
 	AppVer   *version.Version
-	Fields   []StructField
+	Fields   []structfield.ID
 
 	log    logr.Logger
 	tmpDir string
@@ -86,12 +91,67 @@ func newApp(ctx context.Context, l logr.Logger, j job) (*app, error) {
 
 // GetOffset returnst the struct field offset for sf. It uses the DWARF data
 // of the app's built binary to find this value.
-func (a *app) GetOffset(sf StructField) (uint64, bool) {
-	a.log.V(1).Info("analyzing binary...", "package", sf.PkgPath, "binary", a.exec)
-	return sf.offset(a.data)
+func (a *app) GetOffset(id structfield.ID) (uint64, bool) {
+	a.log.V(1).Info("analyzing binary...", "id", id, "binary", a.exec)
+
+	strct := fmt.Sprintf("%s.%s", id.PkgPath, id.Struct)
+	r := a.data.Reader()
+	if !gotoEntry(r, dwarf.TagStructType, strct) {
+		return 0, false
+	}
+
+	e, err := findEntry(r, dwarf.TagMember, id.Field)
+	if err != nil {
+		return 0, false
+	}
+
+	f, ok := entryField(e, dwarf.AttrDataMemberLoc)
+	if !ok {
+		return 0, false
+	}
+
+	return uint64(f.Val.(int64)), true
 }
 
 // Close closes the app, releasing all held resources.
 func (a *app) Close() error {
 	return os.RemoveAll(a.tmpDir)
+}
+
+// gotoEntry reads from r until the entry with a tag equal to name is found.
+// True is returned if the entry is found, otherwise false is returned.
+func gotoEntry(r *dwarf.Reader, tag dwarf.Tag, name string) bool {
+	_, err := findEntry(r, tag, name)
+	return err == nil
+}
+
+// findEntry returns the DWARF entry with a tag equal to name read from r. An
+// error is returned if the entry cannot be found.
+func findEntry(r *dwarf.Reader, tag dwarf.Tag, name string) (*dwarf.Entry, error) {
+	for {
+		entry, err := r.Next()
+		if err == io.EOF || entry == nil {
+			break
+		}
+
+		if entry.Tag == tag {
+			if f, ok := entryField(entry, dwarf.AttrName); ok {
+				if name == f.Val.(string) {
+					return entry, nil
+				}
+			}
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+// entryField returns the DWARF field from DWARF entry e that has the passed
+// DWARF attribute a.
+func entryField(e *dwarf.Entry, a dwarf.Attr) (dwarf.Field, bool) {
+	for _, f := range e.Field {
+		if f.Attr == a {
+			return f, true
+		}
+	}
+	return dwarf.Field{}, false
 }

--- a/internal/tools/inspect/cache.go
+++ b/internal/tools/inspect/cache.go
@@ -50,27 +50,21 @@ func newCache(l logr.Logger) *Cache {
 	return &Cache{log: l.WithName("cache")}
 }
 
-// GetOffset returns the cached offset and true for the StructField at the
-// specified version. If the cache does not contain a valid offset for the
-// provided values, 0 and false are returned.
-func (c *Cache) GetOffset(ver *version.Version, sf StructField) (uint64, bool) {
+// GetOffset returns the cached offset and true for the id at the specified
+// version. If the cache does not contain a valid offset for the provided
+// values, 0 and false are returned.
+func (c *Cache) GetOffset(ver *version.Version, id structfield.ID) (uint64, bool) {
 	if c.data == nil {
 		return 0, false
 	}
 
-	off, ok := c.data.GetOffset(sf.id(), ver)
+	off, ok := c.data.GetOffset(id, ver)
 	msg := "cache "
 	if ok {
 		msg += "hit"
 	} else {
 		msg += "miss"
 	}
-	c.log.V(1).Info(
-		msg,
-		"version", ver,
-		"package", sf.PkgPath,
-		"struct", sf.Struct,
-		"field", sf.Field,
-	)
+	c.log.V(1).Info(msg, "version", ver, "id", id)
 	return off, ok
 }

--- a/internal/tools/inspect/cmd/offsetgen/main.go
+++ b/internal/tools/inspect/cmd/offsetgen/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 
+	"go.opentelemetry.io/auto/internal/pkg/structfield"
 	"go.opentelemetry.io/auto/internal/tools/inspect"
 )
 
@@ -84,97 +85,43 @@ func manifests() ([]inspect.Manifest, error) {
 				Renderer:  ren("templates/runtime/*.tmpl"),
 				GoVerions: goVers,
 			},
-			StructFields: []inspect.StructField{{
-				PkgPath: "runtime",
-				Struct:  "g",
-				Field:   "goid",
-			}, {
-				PkgPath: "runtime",
-				Struct:  "hmap",
-				Field:   "buckets",
-			}},
+			StructFields: []structfield.ID{
+				structfield.NewID("runtime", "g", "goid"),
+				structfield.NewID("runtime", "hmap", "buckets"),
+			},
 		},
 		{
 			Application: inspect.Application{
 				Renderer:  ren("templates/net/http/*.tmpl"),
 				GoVerions: goVers,
 			},
-			StructFields: []inspect.StructField{{
-				PkgPath: "net/http",
-				Struct:  "Request",
-				Field:   "Method",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "Request",
-				Field:   "URL",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "Request",
-				Field:   "RemoteAddr",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "Request",
-				Field:   "Header",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "Request",
-				Field:   "ctx",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "response",
-				Field:   "req",
-			}, {
-				PkgPath: "net/http",
-				Struct:  "response",
-				Field:   "status",
-			}, {
-				PkgPath: "net/url",
-				Struct:  "URL",
-				Field:   "Path",
-			}},
+			StructFields: []structfield.ID{
+				structfield.NewID("net/http", "Request", "Method"),
+				structfield.NewID("net/http", "Request", "URL"),
+				structfield.NewID("net/http", "Request", "RemoteAddr"),
+				structfield.NewID("net/http", "Request", "Header"),
+				structfield.NewID("net/http", "Request", "ctx"),
+				structfield.NewID("net/http", "response", "req"),
+				structfield.NewID("net/http", "response", "status"),
+				structfield.NewID("net/url", "URL", "Path"),
+			},
 		},
 		{
 			Application: inspect.Application{
 				Renderer: ren("templates/google.golang.org/grpc/*.tmpl"),
 				Versions: grpcVers,
 			},
-			StructFields: []inspect.StructField{{
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "Stream",
-				Field:   "method",
-			}, {
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "Stream",
-				Field:   "id",
-			}, {
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "Stream",
-				Field:   "ctx",
-			}, {
-				PkgPath: "google.golang.org/grpc",
-				Struct:  "ClientConn",
-				Field:   "target",
-			}, {
-				PkgPath: "golang.org/x/net/http2",
-				Struct:  "MetaHeadersFrame",
-				Field:   "Fields",
-			}, {
-				PkgPath: "golang.org/x/net/http2",
-				Struct:  "FrameHeader",
-				Field:   "StreamID",
-			}, {
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "http2Client",
-				Field:   "nextID",
-			}, {
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "headerFrame",
-				Field:   "streamID",
-			}, {
-				PkgPath: "google.golang.org/grpc/internal/transport",
-				Struct:  "headerFrame",
-				Field:   "hf",
-			}},
+			StructFields: []structfield.ID{
+				structfield.NewID("google.golang.org/grpc/internal/transport", "Stream", "method"),
+				structfield.NewID("google.golang.org/grpc/internal/transport", "Stream", "id"),
+				structfield.NewID("google.golang.org/grpc/internal/transport", "Stream", "ctx"),
+				structfield.NewID("google.golang.org/grpc", "ClientConn", "target"),
+				structfield.NewID("golang.org/x/net/http2", "MetaHeadersFrame", "Fields"),
+				structfield.NewID("golang.org/x/net/http2", "FrameHeader", "StreamID"),
+				structfield.NewID("google.golang.org/grpc/internal/transport", "http2Client", "nextID"),
+				structfield.NewID("google.golang.org/grpc/internal/transport", "headerFrame", "streamID"),
+				structfield.NewID("google.golang.org/grpc/internal/transport", "headerFrame", "hf"),
+			},
 		},
 	}, nil
 }

--- a/internal/tools/inspect/inspector.go
+++ b/internal/tools/inspect/inspector.go
@@ -134,7 +134,7 @@ type job struct {
 	Renderer Renderer
 	Builder  *builder
 	AppVer   *version.Version
-	Fields   []StructField
+	Fields   []structfield.ID
 }
 
 // Do performs the inspections and returns all found offsets.
@@ -185,7 +185,7 @@ func (i *Inspector) Do(ctx context.Context) (*structfield.Index, error) {
 				continue
 			}
 
-			index.PutOffset(r.StructField.id(), r.Version, r.Offset)
+			index.PutOffset(r.StructField, r.Version, r.Offset)
 		}
 	}
 
@@ -203,7 +203,7 @@ func max(a, b int) int {
 }
 
 type result struct {
-	StructField StructField
+	StructField structfield.ID
 	Version     *version.Version
 	Offset      uint64
 	Found       bool
@@ -255,12 +255,7 @@ func (i *Inspector) do(ctx context.Context, j job) (out []result, err error) {
 
 func (i *Inspector) logResult(r result) {
 	msg := "offset "
-	kv := []interface{}{
-		"version", r.Version,
-		"package", r.StructField.PkgPath,
-		"struct", r.StructField.Struct,
-		"field", r.StructField.Field,
-	}
+	kv := []interface{}{"version", r.Version, "id", r.StructField}
 	if !r.Found {
 		msg += "not found"
 	} else {

--- a/internal/tools/inspect/manifest.go
+++ b/internal/tools/inspect/manifest.go
@@ -15,10 +15,7 @@
 package inspect
 
 import (
-	"debug/dwarf"
 	"errors"
-	"fmt"
-	"io"
 
 	"github.com/hashicorp/go-version"
 
@@ -32,7 +29,7 @@ type Manifest struct {
 	Application Application
 	// StructFields are struct fields the application should contain that need
 	// offsets to be found.
-	StructFields []StructField
+	StructFields []structfield.ID
 }
 
 func (m Manifest) validate() error {
@@ -57,87 +54,4 @@ type Application struct {
 	//
 	// If this is nil, the latest version of Go will be used.
 	GoVerions []*version.Version
-}
-
-// StructField defines a field of a struct from a package.
-type StructField struct {
-	// PkgPath is the unique package import path containing the struct.
-	PkgPath string
-	// Struct is the name of the struct containing the field.
-	Struct string
-	// Field is the name of the field.
-	Field string
-}
-
-// structName returns the package path prefixed struct name of s.
-func (s StructField) structName() string {
-	return fmt.Sprintf("%s.%s", s.PkgPath, s.Struct)
-}
-
-// id returns StructField as an offsets.ID.
-func (s StructField) id() structfield.ID {
-	return structfield.ID{
-		PkgPath: s.PkgPath,
-		Struct:  s.Struct,
-		Field:   s.Field,
-	}
-}
-
-// offset returns the field offset found in the DWARF data d and true. If the
-// offset is not found in d, 0 and false are returned.
-func (s StructField) offset(d *dwarf.Data) (uint64, bool) {
-	r := d.Reader()
-	if !gotoEntry(r, dwarf.TagStructType, s.structName()) {
-		return 0, false
-	}
-
-	e, err := findEntry(r, dwarf.TagMember, s.Field)
-	if err != nil {
-		return 0, false
-	}
-
-	f, ok := entryField(e, dwarf.AttrDataMemberLoc)
-	if !ok {
-		return 0, false
-	}
-
-	return uint64(f.Val.(int64)), true
-}
-
-// gotoEntry reads from r until the entry with a tag equal to name is found.
-// True is returned if the entry is found, otherwise false is returned.
-func gotoEntry(r *dwarf.Reader, tag dwarf.Tag, name string) bool {
-	_, err := findEntry(r, tag, name)
-	return err == nil
-}
-
-// findEntry returns the DWARF entry with a tag equal to name read from r. An
-// error is returned if the entry cannot be found.
-func findEntry(r *dwarf.Reader, tag dwarf.Tag, name string) (*dwarf.Entry, error) {
-	for {
-		entry, err := r.Next()
-		if err == io.EOF || entry == nil {
-			break
-		}
-
-		if entry.Tag == tag {
-			if f, ok := entryField(entry, dwarf.AttrName); ok {
-				if name == f.Val.(string) {
-					return entry, nil
-				}
-			}
-		}
-	}
-	return nil, errors.New("not found")
-}
-
-// entryField returns the DWARF field from DWARF entry e that has the passed
-// DWARF attribute a.
-func entryField(e *dwarf.Entry, a dwarf.Attr) (dwarf.Field, bool) {
-	for _, f := range e.Field {
-		if f.Attr == a {
-			return f, true
-		}
-	}
-	return dwarf.Field{}, false
 }


### PR DESCRIPTION
Unify the way we define these fields in the instrumentation and in the generation.