### PR TITLE
Unify import of `semconv` to v1.21.0

### DIFF
--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/inject"

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"


### PR DESCRIPTION
This isn't a breaking change given our minimal use of the package, but it positions us for forward compatibility when we expand its use (e.g. span attributes).