### PR TITLE
Fix examples build on docker-compose. Create go.mod from the Dockerfile

### DIFF
--- a/examples/httpPlusdb/Dockerfile
+++ b/examples/httpPlusdb/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.21.3
 WORKDIR /app
 COPY . .
+RUN go mod init main
+RUN go mod tidy
 RUN go build -o main
 ENTRYPOINT ["/app/main"]

--- a/examples/httpPlusdb/README.md
+++ b/examples/httpPlusdb/README.md
@@ -14,6 +14,6 @@ docker compose up
 Now, you can hit the server using the below command
 ```
 curl localhost:8080/query_db
-Which will query the dummy sqlite database named test.db
 ```
+Which will query the dummy sqlite database named test.db
 Every hit to the server should generate a trace that we can observe in [Jaeger UI](http://localhost:16686/)

--- a/examples/rolldice/Dockerfile
+++ b/examples/rolldice/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.21.3
 WORKDIR /app
 COPY . .
+RUN go mod init main
+RUN go mod tidy
 RUN go build -o main
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
Running `docker compose build` in the examples folder results in an error since the `go.mod` file is not visible to the docker image.