### PR TITLE
Increase the max length of context chain which is checked by get_pare…

### DIFF
--- a/internal/include/go_context.h
+++ b/internal/include/go_context.h
@@ -18,7 +18,8 @@
 #include "bpf_helpers.h"
 #include "go_types.h"
 
-#define MAX_DISTANCE 10
+// This limit is used to define the max length of the context.Context chain
+#define MAX_DISTANCE 100
 #define MAX_CONCURRENT_SPANS 1000
 
 struct


### PR DESCRIPTION
Increase the max size of the context chain we check in order to find the parent context. The current limit is 10 which may not be enough for some applications.