### PR TITLE
Remove the shared volume from examples

### DIFF
--- a/examples/httpPlusdb/docker-compose.yaml
+++ b/examples/httpPlusdb/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - shared-data:/app
       - /proc:/host/proc
   go-auto:
     depends_on:
@@ -34,7 +33,6 @@ services:
       - OTEL_PROPAGATORS=tracecontext,baggage
       - CGO_ENABLED=1
     volumes:
-      - shared-data:/app
       - /proc:/host/proc
 
   jaeger:
@@ -50,7 +48,3 @@ services:
         limits:
           memory: 300M
     restart: unless-stopped
-
-
-volumes:
-  shared-data:

--- a/examples/rolldice/docker-compose.yaml
+++ b/examples/rolldice/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - shared-data:/app
       - /proc:/host/proc
   go-auto:
     depends_on:
@@ -32,7 +31,6 @@ services:
       - OTEL_SERVICE_NAME=rolldice
       - OTEL_PROPAGATORS=tracecontext,baggage
     volumes:
-      - shared-data:/app
       - /proc:/host/proc
 
   jaeger:
@@ -48,7 +46,3 @@ services:
         limits:
           memory: 300M
     restart: unless-stopped
-
-
-volumes:
-  shared-data:


### PR DESCRIPTION
This shared volumes is not needed. The application data does not need to be shared between the auto-instrumentation image and the application.

Additionally, by using this shared volume it introduces a frustrating bug. When the main app is changed, but the volume already exists, the existing volume will overwrite the change. Meaning the old app will continue to run.