### PR TITLE
Add probe manifest

### DIFF
--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -39,11 +39,9 @@ const name = "google.golang.org/grpc/server"
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
-		Name:   name,
-		Logger: logger.WithName(name),
-		// TODO (#444): Use the actual package being instrumented here. E.g.
-		// InstrumentedPkg: "google.golang.org/grpc",
-		InstrumentedPkg: "google.golang.org/grpc/server",
+		Name:            name,
+		Logger:          logger.WithName(name),
+		InstrumentedPkg: "google.golang.org/grpc",
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -38,11 +38,9 @@ const name = "net/http/client"
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
-		Name:   name,
-		Logger: logger.WithName(name),
-		// TODO (#444): Use the actual package being instrumented here. E.g.
-		// InstrumentedPkg: "net/http",
-		InstrumentedPkg: "net/http/client",
+		Name:            name,
+		Logger:          logger.WithName(name),
+		InstrumentedPkg: "net/http",
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -66,11 +66,12 @@ func NewManager(logger logr.Logger, otelController *opentelemetry.Controller) (*
 }
 
 func (m *Manager) registerProbe(p probe.Probe) error {
-	if _, exists := m.probes[p.LibraryName()]; exists {
-		return fmt.Errorf("library %s registered twice, aborting", p.LibraryName())
+	name := p.Manifest().Name
+	if _, exists := m.probes[name]; exists {
+		return fmt.Errorf("library %s registered twice, aborting", name)
 	}
 
-	m.probes[p.LibraryName()] = p
+	m.probes[name] = p
 	return nil
 }
 
@@ -78,8 +79,8 @@ func (m *Manager) registerProbe(p probe.Probe) error {
 func (m *Manager) GetRelevantFuncs() map[string]interface{} {
 	funcsMap := make(map[string]interface{})
 	for _, i := range m.probes {
-		for _, f := range i.FuncNames() {
-			funcsMap[f] = nil
+		for _, s := range i.Manifest().Symbols {
+			funcsMap[s] = nil
 		}
 	}
 
@@ -96,15 +97,15 @@ func (m *Manager) FilterUnusedProbes(target *process.TargetDetails) {
 
 	for name, inst := range m.probes {
 		funcsFound := 0
-		for _, instF := range inst.FuncNames() {
-			if _, exists := existingFuncMap[instF]; exists {
+		for _, s := range inst.Manifest().Symbols {
+			if _, exists := existingFuncMap[s]; exists {
 				funcsFound++
 			}
 		}
 
-		if funcsFound != len(inst.FuncNames()) {
+		if n := len(inst.Manifest().Symbols); funcsFound != n {
 			if funcsFound > 0 {
-				m.logger.Error(errNotAllFuncsFound, "some of expected functions not found - check instrumented functions", "instrumentation_name", name, "funcs_found", funcsFound, "funcs_expected", len(inst.FuncNames()))
+				m.logger.Error(errNotAllFuncsFound, "some of expected functions not found - check instrumented functions", "instrumentation_name", name, "funcs_found", funcsFound, "funcs_expected", n)
 			}
 			delete(m.probes, name)
 		}
@@ -160,7 +161,7 @@ func (m *Manager) load(target *process.TargetDetails) error {
 
 	// Load probes
 	for name, i := range m.probes {
-		m.logger.Info("loading probes", "name", name)
+		m.logger.Info("loading probe", "name", name)
 		err := i.Load(exe, target)
 		if err != nil {
 			m.logger.Error(err, "error while loading probes, cleaning up", "name", name)

--- a/internal/pkg/instrumentation/probe/manifest.go
+++ b/internal/pkg/instrumentation/probe/manifest.go
@@ -42,13 +42,16 @@ type Manifest struct {
 // and added directly to the returned Manifest.
 func NewManifest(name, pkg string, structfields []structfield.ID, symbols []string) Manifest {
 	sort.Slice(structfields, func(i, j int) bool {
-		if structfields[i].PkgPath == structfields[j].PkgPath {
-			if structfields[i].Struct == structfields[j].Struct {
-				return structfields[i].Field < structfields[j].Field
+		if structfields[i].ModPath == structfields[j].ModPath {
+			if structfields[i].PkgPath == structfields[j].PkgPath {
+				if structfields[i].Struct == structfields[j].Struct {
+					return structfields[i].Field < structfields[j].Field
+				}
+				return structfields[i].Struct < structfields[j].Struct
 			}
-			return structfields[i].Struct < structfields[j].Struct
+			return structfields[i].PkgPath < structfields[j].PkgPath
 		}
-		return structfields[i].PkgPath < structfields[j].PkgPath
+		return structfields[i].ModPath < structfields[j].ModPath
 	})
 
 	sort.Strings(symbols)

--- a/internal/pkg/instrumentation/probe/manifest.go
+++ b/internal/pkg/instrumentation/probe/manifest.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"sort"
+
+	"go.opentelemetry.io/auto/internal/pkg/structfield"
+)
+
+// Manifest contains information about a package being instrumented.
+type Manifest struct {
+	// Name is the unique name of the instrumentation.
+	Name string
+
+	// InstrumentedPkg is the package path of the instrumented code.
+	InstrumentedPkg string
+
+	// StructFields are the struct fields in an instrumented package that are
+	// used for instrumentation.
+	StructFields []structfield.ID
+
+	// Symbols are the runtime symbols that are used to attach a probe's eBPF
+	// program to a perf events.
+	Symbols []string
+}
+
+// NewManifest returns a new Manifest for the instrumentation probe with name
+// that instruments pkg. The structfields and symbols will be sorted in-place
+// and added directly to the returned Manifest.
+func NewManifest(name, pkg string, structfields []structfield.ID, symbols []string) Manifest {
+	sort.Slice(structfields, func(i, j int) bool {
+		if structfields[i].PkgPath == structfields[j].PkgPath {
+			if structfields[i].Struct == structfields[j].Struct {
+				return structfields[i].Field < structfields[j].Field
+			}
+			return structfields[i].Struct < structfields[j].Struct
+		}
+		return structfields[i].PkgPath < structfields[j].PkgPath
+	})
+
+	sort.Strings(symbols)
+
+	return Manifest{
+		Name:            name,
+		InstrumentedPkg: pkg,
+		StructFields:    structfields,
+		Symbols:         symbols,
+	}
+}

--- a/internal/pkg/instrumentation/probe/manifest_test.go
+++ b/internal/pkg/instrumentation/probe/manifest_test.go
@@ -50,12 +50,11 @@ func TestNewManifest(t *testing.T) {
 		[]structfield.ID{sAABB, sABAA, sAAAA, sAAAC, sBAAA, sAAAB, sAABA, sAABC},
 		[]string{d, a, c, b},
 	)
-	assert.Equal(t, name, got.Name)
-	assert.Equal(t, pkg, got.InstrumentedPkg)
-	assert.Equal(t, []string{a, b, c, d}, got.Symbols)
-	assert.Equal(
-		t,
-		[]structfield.ID{sAAAA, sAAAB, sAAAC, sAABA, sAABB, sAABC, sABAA, sBAAA},
-		got.StructFields,
-	)
+	want := Manifest{
+		Name:            name,
+		InstrumentedPkg: pkg,
+		StructFields:    []structfield.ID{sAAAA, sAAAB, sAAAC, sAABA, sAABB, sAABC, sABAA, sBAAA},
+		Symbols:         []string{a, b, c, d},
+	}
+	assert.Equal(t, want, got)
 }

--- a/internal/pkg/instrumentation/probe/manifest_test.go
+++ b/internal/pkg/instrumentation/probe/manifest_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/auto/internal/pkg/structfield"
+)
+
+func TestNewManifest(t *testing.T) {
+	const (
+		name = "name"
+		pkg  = "pkg"
+
+		a = "a"
+		b = "b"
+		c = "c"
+		d = "d"
+	)
+
+	var (
+		sAAAA = structfield.NewID("a", "a/a", "A", "A")
+		sAAAB = structfield.NewID("a", "a/a", "A", "B")
+		sAAAC = structfield.NewID("a", "a/a", "A", "C")
+		sAABA = structfield.NewID("a", "a/a", "B", "A")
+		sAABB = structfield.NewID("a", "a/a", "B", "B")
+		sAABC = structfield.NewID("a", "a/a", "B", "C")
+		sABAA = structfield.NewID("a", "a/b", "A", "A")
+		sBAAA = structfield.NewID("b", "a/a", "A", "A")
+	)
+
+	got := NewManifest(
+		name,
+		pkg,
+		[]structfield.ID{sAABB, sABAA, sAAAA, sAAAC, sBAAA, sAAAB, sAABA, sAABC},
+		[]string{d, a, c, b},
+	)
+	assert.Equal(t, name, got.Name)
+	assert.Equal(t, pkg, got.InstrumentedPkg)
+	assert.Equal(t, []string{a, b, c, d}, got.Symbols)
+	assert.Equal(
+		t,
+		[]structfield.ID{sAAAA, sAAAB, sAAAC, sAABA, sAABB, sAABC, sABAA, sBAAA},
+		got.StructFields,
+	)
+}

--- a/internal/pkg/instrumentation/probe/manifest_test.go
+++ b/internal/pkg/instrumentation/probe/manifest_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/auto/internal/pkg/structfield"
 )
 


### PR DESCRIPTION
Resolve #419 

The added manifest centralizes all the information about a Probe, including its identity and what it injects into the eBPF runtime.

This does fix the probe's instrumentation package name for the grpc server and net/http client instrumentation, but it does not address #444. That is left for a follow-up PR.