### PR TITLE
Fallback to the single offset if possible and version can't be parsed

### DIFF
--- a/internal/pkg/structfield/structfield.go
+++ b/internal/pkg/structfield/structfield.go
@@ -30,10 +30,6 @@ type Index struct {
 	data   map[ID]*Offsets
 }
 
-const (
-	invalidOffset = uint64(0xFFFFFFFFFFFFFFFF)
-)
-
 // NewIndex returns a new empty Index.
 func NewIndex() *Index {
 	return &Index{data: make(map[ID]*Offsets)}
@@ -225,10 +221,15 @@ type Offsets struct {
 	// values is a map between version and offset value.
 	values map[verKey]offsetVersion
 
-	// singleOffset is the single offset in the values map.
-	// If there is only one offset, this will be that offset.
-	// Otherwise, this will be invalidOffset.
-	singleOffset uint64
+	// uo is the single offset in the values map.
+	// If there is only one offset, this will be that offset and valid will be true.
+	// Otherwise, valid is false
+	uo uniqueOffset
+}
+
+type uniqueOffset struct {
+	value uint64
+	valid bool
 }
 
 // NewOffsets returns a new empty *Offsets.
@@ -247,11 +248,11 @@ func (o *Offsets) Get(ver *version.Version) (uint64, bool) {
 	v, ok := o.values[newVerKey(ver)]
 	o.mu.RUnlock()
 
-	if !ok && o.values != nil && o.singleOffset != invalidOffset {
+	if !ok && o.uo.valid {
 		// If we don't have the exact version, but we only have one offset, we
 		// fallback to use that offset. This can happen when a non official version is being used
 		// which contains commit hash in the version string.
-		return o.singleOffset, true
+		return o.uo.value, true
 	}
 	return v.offset, ok
 }
@@ -266,14 +267,15 @@ func (o *Offsets) Put(ver *version.Version, offset uint64) {
 
 	if o.values == nil {
 		o.values = map[verKey]offsetVersion{newVerKey(ver): ov}
-		o.singleOffset = ov.offset
+		o.uo.valid = true
+		o.uo.value = ov.offset
 		return
 	}
 
 	o.values[newVerKey(ver)] = ov
 
-	if o.singleOffset != invalidOffset && o.singleOffset != ov.offset {
-		o.singleOffset = invalidOffset
+	if o.uo.valid && o.uo.value != ov.offset {
+		o.uo.valid = false
 	}
 }
 

--- a/internal/pkg/structfield/structfield.go
+++ b/internal/pkg/structfield/structfield.go
@@ -30,6 +30,10 @@ type Index struct {
 	data   map[ID]*Offsets
 }
 
+const (
+	invalidOffset = uint64(0xFFFFFFFFFFFFFFFF)
+)
+
 // NewIndex returns a new empty Index.
 func NewIndex() *Index {
 	return &Index{data: make(map[ID]*Offsets)}
@@ -221,10 +225,10 @@ type Offsets struct {
 	// values is a map between version and offset value.
 	values map[verKey]offsetVersion
 
-	// singleVer is a pointer to the single version of the Offsets.
-	// If there is only one version, this will be set to that version.
-	// Otherwise, this will be nil.
-	singleVer *offsetVersion
+	// singleOffset is the single offset in the values map.
+	// If there is only one offset, this will be that offset.
+	// Otherwise, this will be invalidOffset.
+	singleOffset uint64
 }
 
 // NewOffsets returns a new empty *Offsets.
@@ -243,11 +247,11 @@ func (o *Offsets) Get(ver *version.Version) (uint64, bool) {
 	v, ok := o.values[newVerKey(ver)]
 	o.mu.RUnlock()
 
-	if !ok && o.singleVer != nil {
-		// If we don't have the exact version, but we only have one version, we
-		// fallback to use that version. This can happen when a non official version is being used
+	if !ok && o.values != nil && o.singleOffset != invalidOffset {
+		// If we don't have the exact version, but we only have one offset, we
+		// fallback to use that offset. This can happen when a non official version is being used
 		// which contains commit hash in the version string.
-		return o.singleVer.offset, true
+		return o.singleOffset, true
 	}
 	return v.offset, ok
 }
@@ -262,14 +266,14 @@ func (o *Offsets) Put(ver *version.Version, offset uint64) {
 
 	if o.values == nil {
 		o.values = map[verKey]offsetVersion{newVerKey(ver): ov}
-		o.singleVer = &ov
+		o.singleOffset = ov.offset
 		return
 	}
 
 	o.values[newVerKey(ver)] = ov
 
-	if o.singleVer != nil && o.singleVer.offset != ov.offset {
-		o.singleVer = nil
+	if o.singleOffset != invalidOffset && o.singleOffset != ov.offset {
+		o.singleOffset = invalidOffset
 	}
 }
 

--- a/internal/pkg/structfield/structfield.go
+++ b/internal/pkg/structfield/structfield.go
@@ -237,6 +237,15 @@ func (o *Offsets) Get(ver *version.Version) (uint64, bool) {
 	o.mu.RLock()
 	v, ok := o.values[newVerKey(ver)]
 	o.mu.RUnlock()
+
+	if !ok && len(o.values) == 1 {
+		// If we don't have the exact version, but we only have one version, we
+		// fallback to use that version. This can happen when a non official version is being used
+		// which contains commit hash in the version string.
+		for _, v := range o.values {
+			return v.offset, true
+		}
+	}
 	return v.offset, ok
 }
 

--- a/internal/pkg/structfield/structfield_test.go
+++ b/internal/pkg/structfield/structfield_test.go
@@ -74,7 +74,7 @@ var index = &Index{
 				newVerKey(v121): {offset: 1, version: v121},
 				newVerKey(v130): {offset: 1, version: v130},
 			},
-			singleOffset: 1,
+			uo: uniqueOffset{value: 1, valid: true},
 		},
 		NewID("std", "net/http", "Request", "URL"): {
 			values: map[verKey]offsetVersion{
@@ -82,19 +82,19 @@ var index = &Index{
 				newVerKey(v121): {offset: 1, version: v121},
 				newVerKey(v130): {offset: 2, version: v130},
 			},
-			singleOffset: invalidOffset,
+			uo: uniqueOffset{value: 0, valid: false},
 		},
 		NewID("std", "net/http", "Response", "Status"): {
 			values: map[verKey]offsetVersion{
 				newVerKey(v120): {offset: 0, version: v120},
 			},
-			singleOffset: 0,
+			uo: uniqueOffset{value: 0, valid: true},
 		},
 		NewID("google.golang.org/grpc", "google.golang.org/grpc", "ClientConn", "target"): {
 			values: map[verKey]offsetVersion{
 				newVerKey(v120): {offset: 0, version: v120},
 			},
-			singleOffset: 0,
+			uo: uniqueOffset{value: 0, valid: true},
 		},
 	},
 }

--- a/internal/pkg/structfield/structfield_test.go
+++ b/internal/pkg/structfield/structfield_test.go
@@ -74,6 +74,7 @@ var index = &Index{
 				newVerKey(v121): {offset: 1, version: v121},
 				newVerKey(v130): {offset: 1, version: v130},
 			},
+			singleOffset: 1,
 		},
 		NewID("std", "net/http", "Request", "URL"): {
 			values: map[verKey]offsetVersion{
@@ -81,16 +82,19 @@ var index = &Index{
 				newVerKey(v121): {offset: 1, version: v121},
 				newVerKey(v130): {offset: 2, version: v130},
 			},
+			singleOffset: invalidOffset,
 		},
 		NewID("std", "net/http", "Response", "Status"): {
 			values: map[verKey]offsetVersion{
 				newVerKey(v120): {offset: 0, version: v120},
 			},
+			singleOffset: 0,
 		},
 		NewID("google.golang.org/grpc", "google.golang.org/grpc", "ClientConn", "target"): {
 			values: map[verKey]offsetVersion{
 				newVerKey(v120): {offset: 0, version: v120},
 			},
+			singleOffset: 0,
 		},
 	},
 }


### PR DESCRIPTION
The main goal of this PR is to handle cases where an offset is required for a package with an  un-official version (contains commit hash: for example `v0.0.0-20230227094218-b8c73b2037b8`
Currenly we can't handle such cases since we don't find a valid version.
I added a fallback to check if only a single offset were saved across all versions to use that offset. If more than one offset was saved and the version is not foundd, fail.
A more robust solution is probably required to handle this kind of version, but this fallback is a good solution until then.