### PR TITLE
Use OTel recommended naming for instrumentation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Changed
+
+- The instrumentation scope name for the `database/sql` instrumentation is now `go.opentelemtry.io/auto/database/sql`. (#507)
+- The instrumentation scope name for the `gin` instrumentation is now `go.opentelemtry.io/auto/github.com/gin-gonic/gin`. (#507)
+- The instrumentation scope name for the `google.golang.org/grpc/client` instrumentation is now `go.opentelemtry.io/auto/google.golang.org/grpc`. (#507)
+- The instrumentation scope name for the `google.golang.org/grpc/server` instrumentation is now `go.opentelemtry.io/auto/google.golang.org/grpc`. (#507)
+- The instrumentation scope name for the `net/http/client` instrumentation is now `go.opentelemtry.io/auto/net/http`. (#507)
+- The instrumentation scope name for the `net/http/server` instrumentation is now `go.opentelemtry.io/auto/net/http`. (#507)
+
 ## [v0.8.0-alpha] - 2023-11-14
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ fixtures/%:
 	if [ ! -d "opentelemetry-helm-charts" ]; then \
 		git clone https://github.com/open-telemetry/opentelemetry-helm-charts.git; \
 	fi
-	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
+	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/opentelemetry-collector
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ fixtures/%:
 	if [ ! -d "opentelemetry-helm-charts" ]; then \
 		git clone https://github.com/open-telemetry/opentelemetry-helm-charts.git; \
 	fi
-	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/opentelemetry-collector
+	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
 	kubectl wait --for=condition=Complete --timeout=60s job/sample-job

--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -33,18 +33,22 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-// name is the instrumentation name.
-const name = "database/sql"
+const (
+	// name is the instrumentation name.
+	name = "database/sql"
+	// pkg is the package being instrumented.
+	pkg = "database/sql"
 
-// IncludeDBStatementEnvVar is the environment variable to opt-in for sql query inclusion in the trace.
-const IncludeDBStatementEnvVar = "OTEL_GO_AUTO_INCLUDE_DB_STATEMENT"
+	// IncludeDBStatementEnvVar is the environment variable to opt-in for sql query inclusion in the trace.
+	IncludeDBStatementEnvVar = "OTEL_GO_AUTO_INCLUDE_DB_STATEMENT"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "database/sql",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},
@@ -158,7 +162,7 @@ func convertEvent(e *event) *probe.Event {
 	}
 
 	return &probe.Event{
-		Library:     name,
+		Package:     pkg,
 		Name:        "DB",
 		Kind:        trace.SpanKindClient,
 		StartTime:   int64(e.StartTime),

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -51,7 +51,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		TraceFlags: trace.FlagsSampled,
 	})
 	want := &probe.Event{
-		Library:     name,
+		Package:     pkg,
 		Name:        "DB",
 		Kind:        trace.SpanKindClient,
 		StartTime:   int64(start.UnixNano()),

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
@@ -33,15 +33,19 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-// name is the instrumentation name.
-const name = "github.com/gin-gonic/gin"
+const (
+	// name is the instrumentation name.
+	name = "github.com/gin-gonic/gin"
+	// pkg is the package being instrumented.
+	pkg = "github.com/gin-gonic/gin"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "github.com/gin-gonic/gin",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.StructFieldConst{
@@ -122,7 +126,7 @@ func convertEvent(e *event) *probe.Event {
 	})
 
 	return &probe.Event{
-		Library: name,
+		Package: pkg,
 		// Do not include the high-cardinality path here (there is no
 		// templatized path manifest to reference, given we are instrumenting
 		// Engine.ServeHTTP which is not passed a Gin Context).

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe_test.go
@@ -52,7 +52,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		TraceFlags: trace.FlagsSampled,
 	})
 	want := &probe.Event{
-		Library:     name,
+		Package:     pkg,
 		Name:        "GET",
 		Kind:        trace.SpanKindServer,
 		StartTime:   int64(start.UnixNano()),

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
@@ -35,15 +35,19 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-// name is the instrumentation name.
-const name = "google.golang.org/grpc"
+const (
+	// name is the instrumentation name.
+	name = "google.golang.org/grpc/client"
+	// pkg is the package being instrumented.
+	pkg = "google.golang.org/grpc"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "google.golang.org/grpc",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},
@@ -164,7 +168,7 @@ func convertEvent(e *event) *probe.Event {
 	}
 
 	return &probe.Event{
-		Library:           name,
+		Package:           pkg,
 		Name:              method,
 		Kind:              trace.SpanKindClient,
 		StartTime:         int64(e.StartTime),

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -33,15 +33,19 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-// name is the instrumentation name.
-const name = "google.golang.org/grpc/server"
+const (
+	// name is the instrumentation name.
+	name = "google.golang.org/grpc/server"
+	// pkg is the package being instrumented.
+	pkg = "google.golang.org/grpc"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "google.golang.org/grpc",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},
@@ -152,7 +156,7 @@ func convertEvent(e *event) *probe.Event {
 	}
 
 	return &probe.Event{
-		Library:   name,
+		Package:   pkg,
 		Name:      method,
 		Kind:      trace.SpanKindServer,
 		StartTime: int64(e.StartTime),

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -33,14 +33,19 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-const name = "net/http/client"
+const (
+	// name is the instrumentation name.
+	name = "net/http/client"
+	// pkg is the package being instrumented.
+	pkg = "net/http"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "net/http",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.AllocationConst{},
@@ -143,7 +148,7 @@ func convertEvent(e *event) *probe.Event {
 	}
 
 	return &probe.Event{
-		Library:     name,
+		Package:     pkg,
 		Name:        path,
 		Kind:        trace.SpanKindClient,
 		StartTime:   int64(e.StartTime),

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -33,14 +33,19 @@ import (
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64,arm64 -cc clang -cflags $CFLAGS bpf ./bpf/probe.bpf.c
 
-const name = "net/http"
+const (
+	// name is the instrumentation name.
+	name = "net/http/server"
+	// pkg is the package being instrumented.
+	pkg = "net/http"
+)
 
 // New returns a new [probe.Probe].
 func New(logger logr.Logger) probe.Probe {
 	return &probe.Base[bpfObjects, event]{
 		Name:            name,
 		Logger:          logger.WithName(name),
-		InstrumentedPkg: "net/http",
+		InstrumentedPkg: pkg,
 		Consts: []probe.Const{
 			probe.RegistersABIConst{},
 			probe.StructFieldConst{
@@ -151,7 +156,7 @@ func convertEvent(e *event) *probe.Event {
 	}
 
 	return &probe.Event{
-		Library: name,
+		Package: pkg,
 		// Do not include the high-cardinality path here (there is no
 		// templatized path manifest to reference).
 		Name:              method,

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
@@ -54,7 +54,7 @@ func TestProbeConvertEvent(t *testing.T) {
 		TraceFlags: trace.FlagsSampled,
 	})
 	want := &probe.Event{
-		Library:     name,
+		Package:     pkg,
 		Name:        "GET",
 		Kind:        trace.SpanKindServer,
 		StartTime:   int64(start.UnixNano()),

--- a/internal/pkg/instrumentation/probe/event.go
+++ b/internal/pkg/instrumentation/probe/event.go
@@ -21,7 +21,7 @@ import (
 
 // Event is a telemetry event that happens within an instrumented package.
 type Event struct {
-	Library           string
+	Package           string
 	Name              string
 	Attributes        []attribute.KeyValue
 	Kind              trace.SpanKind

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -35,17 +35,17 @@ type Controller struct {
 	bootTime       int64
 }
 
-func (c *Controller) getTracer(libName string) trace.Tracer {
-	t, exists := c.tracersMap[libName]
+func (c *Controller) getTracer(pkg string) trace.Tracer {
+	t, exists := c.tracersMap[pkg]
 	if exists {
 		return t
 	}
 
 	newTracer := c.tracerProvider.Tracer(
-		libName,
+		"go.opentelemetry.io/auto/"+pkg,
 		trace.WithInstrumentationVersion(c.version),
 	)
-	c.tracersMap[libName] = newTracer
+	c.tracersMap[pkg] = newTracer
 	return newTracer
 }
 
@@ -65,7 +65,7 @@ func (c *Controller) Trace(event *probe.Event) {
 	}
 
 	ctx = ContextWithEBPFEvent(ctx, *event)
-	_, span := c.getTracer(event.Library).
+	_, span := c.getTracer(event.Package).
 		Start(ctx, event.Name,
 			trace.WithAttributes(event.Attributes...),
 			trace.WithSpanKind(event.Kind),

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -45,7 +45,7 @@
       "scopeSpans": [
         {
           "scope": {
-            "name": "database/sql",
+            "name": "go.opentelemetry.io/auto/database/sql",
             "version": "v0.8.0-alpha"
           },
           "spans": [
@@ -69,7 +69,7 @@
         },
         {
           "scope": {
-            "name": "net/http",
+            "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.8.0-alpha"
           },
           "spans": [
@@ -100,15 +100,7 @@
               "spanId": "xxxxx",
               "status": {},
               "traceId": "xxxxx"
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "net/http/client",
-            "version": "v0.8.0-alpha"
-          },
-          "spans": [
+            },
             {
               "attributes": [
                 {

--- a/internal/test/e2e/databasesql/verify.bats
+++ b/internal/test/e2e/databasesql/verify.bats
@@ -2,29 +2,29 @@
 
 load ../../test_helpers/utilities
 
-LIBRARY_NAME="database/sql"
+SCOPE="go.opentelemetry.io/auto/database/sql"
 
-@test "${LIBRARY_NAME} :: includes db.statement attribute" {
-  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"db.statement\").value.stringValue")
+@test "${SCOPE} :: includes db.statement attribute" {
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.statement\").value.stringValue")
   assert_equal "$result" '"SELECT * FROM contacts"'
 }
 
-@test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+@test "${SCOPE} :: trace ID present and valid in all spans" {
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+@test "${SCOPE} :: span ID present and valid in all spans" {
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${LIBRARY_NAME} :: parent span ID present and valid in all spans" {
-  parent_span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".parentSpanId")
+@test "${SCOPE} :: parent span ID present and valid in all spans" {
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${LIBRARY_NAME} :: expected (redacted) trace output" {
+@test "${SCOPE} :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -45,7 +45,7 @@
       "scopeSpans": [
         {
           "scope": {
-            "name": "github.com/gin-gonic/gin",
+            "name": "go.opentelemetry.io/auto/github.com/gin-gonic/gin",
             "version": "v0.8.0-alpha"
           },
           "spans": [
@@ -75,7 +75,7 @@
         },
         {
           "scope": {
-            "name": "net/http/client",
+            "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.8.0-alpha"
           },
           "spans": [

--- a/internal/test/e2e/gin/verify.bats
+++ b/internal/test/e2e/gin/verify.bats
@@ -2,39 +2,39 @@
 
 load ../../test_helpers/utilities
 
-LIBRARY_NAME="github.com/gin-gonic/gin"
+SCOPE="go.opentelemetry.io/auto/github.com/gin-gonic/gin"
 
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "${LIBRARY_NAME} :: emits a span name '{http.method}' (per semconv)" {
-  result=$(span_names_for ${LIBRARY_NAME})
+@test "${SCOPE} :: emits a span name '{http.method}' (per semconv)" {
+  result=$(span_names_for ${SCOPE})
   assert_equal "$result" '"GET"'
 }
 
-@test "${LIBRARY_NAME} :: includes http.method attribute" {
-  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+@test "${SCOPE} :: includes http.method attribute" {
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"http.method\").value.stringValue")
   assert_equal "$result" '"GET"'
 }
 
-@test "${LIBRARY_NAME} :: includes http.target attribute" {
-  result=$(span_attributes_for ${LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+@test "${SCOPE} :: includes http.target attribute" {
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"http.target\").value.stringValue")
   assert_equal "$result" '"/hello-gin"'
 }
 
-@test "${LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".traceId")
+@test "${SCOPE} :: trace ID present and valid in all spans" {
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${LIBRARY_NAME} | jq ".spanId")
+@test "${SCOPE} :: span ID present and valid in all spans" {
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${LIBRARY_NAME} :: expected (redacted) trace output" {
+@test "${SCOPE} :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -45,7 +45,7 @@
       "scopeSpans": [
         {
           "scope": {
-            "name": "google.golang.org/grpc",
+            "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
             "version": "v0.8.0-alpha"
           },
           "spans": [
@@ -82,15 +82,7 @@
               "spanId": "xxxxx",
               "status": {},
               "traceId": "xxxxx"
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "google.golang.org/grpc/server",
-            "version": "v0.8.0-alpha"
-          },
-          "spans": [
+            },
             {
               "attributes": [
                 {

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -79,9 +79,9 @@
               "kind": 3,
               "name": "/helloworld.Greeter/SayHello",
               "parentSpanId": "",
-              "spanId": "xxxxx<-INVALID",
+              "spanId": "xxxxx",
               "status": {},
-              "traceId": "xxxxx<-INVALID"
+              "traceId": "xxxxx"
             },
             {
               "attributes": [
@@ -101,9 +101,9 @@
               "kind": 2,
               "name": "/helloworld.Greeter/SayHello",
               "parentSpanId": "xxxxx",
-              "spanId": "xxxxx<-INVALID",
+              "spanId": "xxxxx",
               "status": {},
-              "traceId": "xxxxx<-INVALID"
+              "traceId": "xxxxx"
             }
           ]
         }

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -79,9 +79,9 @@
               "kind": 3,
               "name": "/helloworld.Greeter/SayHello",
               "parentSpanId": "",
-              "spanId": "xxxxx",
+              "spanId": "xxxxx<-INVALID",
               "status": {},
-              "traceId": "xxxxx"
+              "traceId": "xxxxx<-INVALID"
             },
             {
               "attributes": [
@@ -101,9 +101,9 @@
               "kind": 2,
               "name": "/helloworld.Greeter/SayHello",
               "parentSpanId": "xxxxx",
-              "spanId": "xxxxx",
+              "spanId": "xxxxx<-INVALID",
               "status": {},
-              "traceId": "xxxxx"
+              "traceId": "xxxxx<-INVALID"
             }
           ]
         }

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -52,6 +52,28 @@
             {
               "attributes": [
                 {
+                  "key": "rpc.system",
+                  "value": {
+                    "stringValue": "grpc"
+                  }
+                },
+                {
+                  "key": "rpc.service",
+                  "value": {
+                    "stringValue": "/helloworld.Greeter/SayHello"
+                  }
+                }
+              ],
+              "kind": 2,
+              "name": "/helloworld.Greeter/SayHello",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
                   "key": "net.peer.port",
                   "value": {
                     "stringValue": "1701"
@@ -79,28 +101,6 @@
               "kind": 3,
               "name": "/helloworld.Greeter/SayHello",
               "parentSpanId": "",
-              "spanId": "xxxxx",
-              "status": {},
-              "traceId": "xxxxx"
-            },
-            {
-              "attributes": [
-                {
-                  "key": "rpc.system",
-                  "value": {
-                    "stringValue": "grpc"
-                  }
-                },
-                {
-                  "key": "rpc.service",
-                  "value": {
-                    "stringValue": "/helloworld.Greeter/SayHello"
-                  }
-                }
-              ],
-              "kind": 2,
-              "name": "/helloworld.Greeter/SayHello",
-              "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},
               "traceId": "xxxxx"

--- a/internal/test/e2e/grpc/verify.bats
+++ b/internal/test/e2e/grpc/verify.bats
@@ -2,82 +2,81 @@
 
 load ../../test_helpers/utilities
 
-SERVER_LIBRARY_NAME="google.golang.org/grpc/server"
-CLIENT_LIBRARY_NAME="google.golang.org/grpc"
+SCOPE="go.opentelemetry.io/auto/google.golang.org/grpc"
 
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: emits a span name 'SayHello'" {
-  result=$(span_names_for ${SERVER_LIBRARY_NAME})
+@test "server :: emits a span name 'SayHello'" {
+  result=$(server_span_names_for ${SCOPE})
   assert_equal "$result" '"/helloworld.Greeter/SayHello"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: includes rpc.system attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"rpc.system\").value.stringValue")
+@test "server :: includes rpc.system attribute" {
+  result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"rpc.system\").value.stringValue")
   assert_equal "$result" '"grpc"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: includes rpc.service attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"rpc.service\").value.stringValue")
+@test "server :: includes rpc.service attribute" {
+  result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"rpc.service\").value.stringValue")
   assert_equal "$result" '"/helloworld.Greeter/SayHello"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".traceId")
+@test "server :: trace ID present and valid in all spans" {
+  trace_id=$(server_spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${SERVER_LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".spanId")
+@test "server :: span ID present and valid in all spans" {
+  span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${SERVER_LIBRARY_NAME} :: parent span ID present and valid in all spans" {
-  parent_span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".parentSpanId")
+@test "server :: parent span ID present and valid in all spans" {
+  parent_span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${CLIENT_LIBRARY_NAME}, ${SERVER_LIBRARY_NAME} :: spans have same trace ID" {
-  client_trace_id=$(spans_from_scope_named ${CLIENT_LIBRARY_NAME} | jq ".traceId")
-  server_trace_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".traceId")
+@test "client, server :: spans have same trace ID" {
+  client_trace_id=$(client_spans_from_scope_named ${SCOPE} | jq ".traceId")
+  server_trace_id=$(server_spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_equal "$server_trace_id" "$client_trace_id"
 }
 
-@test "${CLIENT_LIBRARY_NAME}, ${SERVER_LIBRARY_NAME} :: server span has client span as parent" {
-  server_parent_span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".parentSpanId")
-  client_span_id=$(spans_from_scope_named ${CLIENT_LIBRARY_NAME} | jq ".spanId")
+@test "client, server :: server span has client span as parent" {
+  server_parent_span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
+  client_span_id=$(client_spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_equal "$client_span_id" "$server_parent_span_id"
 }
 
-@test "${SERVER_LIBRARY_NAME} :: expected (redacted) trace output" {
+@test "server :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }
 
-@test "${CLIENT_LIBRARY_NAME} :: emits a span name 'SayHello'" {
-  result=$(span_names_for ${SERVER_LIBRARY_NAME})
+@test "client :: emits a span name 'SayHello'" {
+  result=$(client_span_names_for ${SCOPE})
   assert_equal "$result" '"/helloworld.Greeter/SayHello"'
 }
 
-@test "${CLIENT_LIBRARY_NAME} :: includes rpc.system attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"rpc.system\").value.stringValue")
+@test "client :: includes rpc.system attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"rpc.system\").value.stringValue")
   assert_equal "$result" '"grpc"'
 }
 
-@test "${CLIENT_LIBRARY_NAME} :: includes rpc.service attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"rpc.service\").value.stringValue")
+@test "client :: includes rpc.service attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"rpc.service\").value.stringValue")
   assert_equal "$result" '"/helloworld.Greeter/SayHello"'
 }
 
-@test "${CLIENT_LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".traceId")
+@test "client :: trace ID present and valid in all spans" {
+  trace_id=$(client_spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${CLIENT_LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".spanId")
+@test "client :: span ID present and valid in all spans" {
+  span_id=$(client_spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -45,7 +45,7 @@
       "scopeSpans": [
         {
           "scope": {
-            "name": "net/http",
+            "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.8.0-alpha"
           },
           "spans": [
@@ -76,15 +76,7 @@
               "spanId": "xxxxx",
               "status": {},
               "traceId": "xxxxx"
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "net/http/client",
-            "version": "v0.8.0-alpha"
-          },
-          "spans": [
+            },
             {
               "attributes": [
                 {

--- a/internal/test/e2e/nethttp/verify.bats
+++ b/internal/test/e2e/nethttp/verify.bats
@@ -2,62 +2,61 @@
 
 load ../../test_helpers/utilities
 
-SERVER_LIBRARY_NAME="net/http"
-CLIENT_LIBRARY_NAME="net/http/client"
+SCOPE="go.opentelemetry.io/auto/net/http"
 
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   assert_equal "$result" '"sample-app"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: emits a span name '{http.method}' (per semconv)" {
-  result=$(span_names_for ${SERVER_LIBRARY_NAME})
+@test "server :: emits a span name '{http.method}' (per semconv)" {
+  result=$(server_span_names_for ${SCOPE})
   assert_equal "$result" '"GET"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: includes http.method attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"http.method\").value.stringValue")
+@test "server :: includes http.method attribute" {
+  result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"http.method\").value.stringValue")
   assert_equal "$result" '"GET"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: includes http.target attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"http.target\").value.stringValue")
+@test "server :: includes http.target attribute" {
+  result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"http.target\").value.stringValue")
   assert_equal "$result" '"/hello"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: includes http.status_code attribute" {
-  result=$(span_attributes_for ${SERVER_LIBRARY_NAME} | jq "select(.key == \"http.status_code\").value.intValue")
+@test "server :: includes http.status_code attribute" {
+  result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"http.status_code\").value.intValue")
   assert_equal "$result" '"200"'
 }
 
-@test "${SERVER_LIBRARY_NAME} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".traceId")
+@test "server :: trace ID present and valid in all spans" {
+  trace_id=$(server_spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
-@test "${SERVER_LIBRARY_NAME} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".spanId")
+@test "server :: span ID present and valid in all spans" {
+  span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${SERVER_LIBRARY_NAME} :: parent span ID present and valid in all spans" {
-  parent_span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".parentSpanId")
+@test "server :: parent span ID present and valid in all spans" {
+  parent_span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 
-@test "${CLIENT_LIBRARY_NAME}, ${SERVER_LIBRARY_NAME} :: spans have same trace ID" {
-  client_trace_id=$(spans_from_scope_named ${CLIENT_LIBRARY_NAME} | jq ".traceId")
-  server_trace_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".traceId")
+@test "client, server :: spans have same trace ID" {
+  client_trace_id=$(server_spans_from_scope_named ${SCOPE} | jq ".traceId")
+  server_trace_id=$(client_spans_from_scope_named ${SCOPE} | jq ".traceId")
   assert_equal "$server_trace_id" "$client_trace_id"
 }
 
-@test "${CLIENT_LIBRARY_NAME}, ${SERVER_LIBRARY_NAME} :: server span has client span as parent" {
-  server_parent_span_id=$(spans_from_scope_named ${SERVER_LIBRARY_NAME} | jq ".parentSpanId")
-  client_span_id=$(spans_from_scope_named ${CLIENT_LIBRARY_NAME} | jq ".spanId")
+@test "client, server :: server span has client span as parent" {
+  server_parent_span_id=$(server_spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
+  client_span_id=$(client_spans_from_scope_named ${SCOPE} | jq ".spanId")
   assert_equal "$client_span_id" "$server_parent_span_id"
 }
 
-@test "${SERVER_LIBRARY_NAME} :: expected (redacted) trace output" {
+@test "server :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/internal/test/test_helpers/utilities.bash
+++ b/internal/test/test_helpers/utilities.bash
@@ -6,11 +6,39 @@ span_names_for() {
 	spans_from_scope_named $1 | jq '.name'
 }
 
+# Returns a list of server span names emitted by a given library/scope
+	# $1 - library/scope name
+server_span_names_for() {
+	server_spans_from_scope_named $1 | jq '.name'
+}
+
+# Returns a list of client span names emitted by a given library/scope
+	# $1 - library/scope name
+client_span_names_for() {
+	client_spans_from_scope_named $1 | jq '.name'
+}
+
 # Returns a list of attributes emitted by a given library/scope
 span_attributes_for() {
 	# $1 - library/scope name
 
 	spans_from_scope_named $1 | \
+		jq ".attributes[]"
+}
+
+# Returns a list of attributes emitted by a given library/scope on server spans.
+server_span_attributes_for() {
+	# $1 - library/scope name
+
+	server_spans_from_scope_named $1 | \
+		jq ".attributes[]"
+}
+
+# Returns a list of attributes emitted by a given library/scope on clinet_spans.
+client_span_attributes_for() {
+	# $1 - library/scope name
+
+	client_spans_from_scope_named $1 | \
 		jq ".attributes[]"
 }
 
@@ -23,6 +51,18 @@ resource_attributes_received() {
 	# $1 - library/scope name
 spans_from_scope_named() {
 	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
+}
+
+# Returns an array of all server spans emitted by a given library/scope
+	# $1 - library/scope name
+server_spans_from_scope_named() {
+	spans_from_scope_named $1 | jq "select(.kind == 2)"
+}
+
+# Returns an array of all client spans emitted by a given library/scope
+	# $1 - library/scope name
+client_spans_from_scope_named() {
+	spans_from_scope_named $1 | jq "select(.kind == 3)"
 }
 
 # Returns an array of all spans received


### PR DESCRIPTION
Resolve #444

- Identify the instrumentation package in the instrumentation scope by using the instrumented package with a prefix of `go.opentelemetry.io/auto` as the scope name.
- Unify client/server telemetry under the same scope.