### PR TITLE
Print the tail of the verifier log

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -67,12 +67,20 @@ jobs:
         run: |
           kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
       - name: check job status
+        id: job-status
         run: |
-          kubectl wait --for=condition=Complete --timeout=60s job/sample-job || kubectl logs -l app=sample -c auto-instrumentation
+          kubectl wait --for=condition=Complete --timeout=60s job/sample-job
       - name: copy telemetry trace output
         run: |
           kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./internal/test/e2e/${{ matrix.library }}/traces-orig.json
           rm -f ./internal/test/e2e/${{ matrix.library }}/traces.json
+        if: steps.job-status.outcome == 'success'
+      - name: print auto-instrumentation logs
+        run: |
+          kubectl logs -l app=sample -c auto-instrumentation
+          exit 1
+        if: steps.job-status.outcome == 'failure'
       - name: verify output and redact to traces.json
         run: |
           bats ./internal/test/e2e/${{ matrix.library }}/verify.bats
+        if: steps.job-status.outcome == 'success'

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,13 @@ fixtures/%:
 	helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
 	kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
 	kubectl -n default create -f .github/workflows/e2e/k8s/sample-job.yml
-	kubectl wait --for=condition=Complete --timeout=60s job/sample-job || kubectl logs -l app=sample -c auto-instrumentation
-	kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./internal/test/e2e/$(LIBRARY)/traces-orig.json
-	rm -f ./internal/test/e2e/$(LIBRARY)/traces.json
-	bats ./internal/test/e2e/$(LIBRARY)/verify.bats
+	if kubectl wait --for=condition=Complete --timeout=60s job/sample-job; then \
+		kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./internal/test/e2e/$(LIBRARY)/traces-orig.json; \
+		rm -f ./internal/test/e2e/$(LIBRARY)/traces.json; \
+		bats ./internal/test/e2e/$(LIBRARY)/verify.bats; \
+	else \
+		kubectl logs -l app=sample -c auto-instrumentation; \
+	fi
 	kind delete cluster
 
 .PHONY: prerelease

--- a/internal/pkg/instrumentation/utils/ebpf.go
+++ b/internal/pkg/instrumentation/utils/ebpf.go
@@ -41,7 +41,7 @@ func LoadEBPFObjects(spec *ebpf.CollectionSpec, to interface{}, opts *ebpf.Colle
 	if err != nil && showVerifierLogs {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {
-			fmt.Printf("Verifier log: %+v\n", ve)
+			fmt.Printf("Verifier log: %-100v\n", ve)
 		}
 	}
 


### PR DESCRIPTION
* Print the tail of the verifier log to give a better summary of the error in case it is truncated.
* In `kind.yml` print the logs in case of failure.