### PR TITLE
Add the ability to define an optional uprobe.

### DIFF
--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -57,9 +57,15 @@ func New(logger logr.Logger) probe.Probe {
 				Val: shouldIncludeDBStatement(),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"database/sql.(*DB).queryDC": uprobeQueryDC,
-			"database/sql.(*DB).execDC":  uprobeExecDC,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "database/sql.(*DB).queryDC",
+				Fn:  uprobeQueryDC,
+			},
+			{
+				Sym: "database/sql.(*DB).execDC",
+				Fn:  uprobeExecDC,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/gin-gonic/gin/probe.go
@@ -65,8 +65,11 @@ func New(logger logr.Logger) probe.Probe {
 				Val: structfield.NewID("std", "net/url", "URL", "Path"),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"github.com/gin-gonic/gin.(*Engine).ServeHTTP": uprobeServeHTTP,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "github.com/gin-gonic/gin.(*Engine).ServeHTTP",
+				Fn:  uprobeServeHTTP,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
@@ -88,10 +88,20 @@ func New(logger logr.Logger) probe.Probe {
 				Val: uint64(attribute.STRINGSLICE),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"go.opentelemetry.io/otel/internal/global.(*tracer).Start":                   uprobeTracerStart,
-			"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).SetAttributes": uprobeSetAttributes,
-			"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).End":           uprobeSpanEnd,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "go.opentelemetry.io/otel/internal/global.(*tracer).Start",
+				Fn:  uprobeTracerStart,
+			},
+			{
+				Sym:      "go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).SetAttributes",
+				Fn:       uprobeSetAttributes,
+				Optional: true,
+			},
+			{
+				Sym: "go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).End",
+				Fn:  uprobeSpanEnd,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/probe.go
@@ -68,15 +68,22 @@ func New(logger logr.Logger) probe.Probe {
 				Val: structfield.NewID("google.golang.org/grpc", "google.golang.org/grpc/internal/transport", "headerFrame", "streamID"),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"google.golang.org/grpc.(*ClientConn).Invoke": uprobeInvoke,
-			"google.golang.org/grpc/internal/transport.(*http2Client).NewStream": func(name string, exec *link.Executable, target *process.TargetDetails, obj *bpfObjects) ([]link.Link, error) {
-				prog := obj.UprobeHttp2ClientNewStream
-				return uprobeFn(name, exec, target, prog)
-			},
-			"google.golang.org/grpc/internal/transport.(*loopyWriter).headerHandler": func(name string, exec *link.Executable, target *process.TargetDetails, obj *bpfObjects) ([]link.Link, error) {
-				prog := obj.UprobeLoopyWriterHeaderHandler
-				return uprobeFn(name, exec, target, prog)
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "google.golang.org/grpc.(*ClientConn).Invoke",
+				Fn:  uprobeInvoke,
+			}, {
+				Sym: "google.golang.org/grpc/internal/transport.(*http2Client).NewStream",
+				Fn: func(name string, exec *link.Executable, target *process.TargetDetails, obj *bpfObjects) ([]link.Link, error) {
+					prog := obj.UprobeHttp2ClientNewStream
+					return uprobeFn(name, exec, target, prog)
+				},
+			}, {
+				Sym: "google.golang.org/grpc/internal/transport.(*loopyWriter).headerHandler",
+				Fn: func(name string, exec *link.Executable, target *process.TargetDetails, obj *bpfObjects) ([]link.Link, error) {
+					prog := obj.UprobeLoopyWriterHeaderHandler
+					return uprobeFn(name, exec, target, prog)
+				},
 			},
 		},
 

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -70,9 +70,15 @@ func New(logger logr.Logger) probe.Probe {
 				Val: structfield.NewID("golang.org/x/net", "golang.org/x/net/http2", "FrameHeader", "StreamID"),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"google.golang.org/grpc.(*Server).handleStream":                           uprobeHandleStream,
-			"google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders": uprobeOperateHeaders,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "google.golang.org/grpc.(*Server).handleStream",
+				Fn:  uprobeHandleStream,
+			},
+			{
+				Sym: "google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders",
+				Fn:  uprobeOperateHeaders,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -78,8 +78,11 @@ func New(logger logr.Logger) probe.Probe {
 				Val: structfield.NewID("std", "runtime", "hmap", "buckets"),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"net/http.(*Transport).roundTrip": uprobeRoundTrip,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "net/http.(*Transport).roundTrip",
+				Fn:  uprobeRoundTrip,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -81,8 +81,11 @@ func New(logger logr.Logger) probe.Probe {
 				Val: structfield.NewID("std", "runtime", "hmap", "buckets"),
 			},
 		},
-		Uprobes: map[string]probe.UprobeFunc[bpfObjects]{
-			"net/http.serverHandler.ServeHTTP": uprobeServeHTTP,
+		Uprobes: []probe.Uprobe[bpfObjects]{
+			{
+				Sym: "net/http.serverHandler.ServeHTTP",
+				Fn:  uprobeServeHTTP,
+			},
 		},
 
 		ReaderFn: func(obj bpfObjects) (*perf.Reader, error) {

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -35,9 +35,6 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
 
-// Error message returned when unable to find all instrumentation functions.
-var errNotAllFuncsFound = fmt.Errorf("not all functions found for instrumentation")
-
 // Manager handles the management of [probe.Probe] instances.
 type Manager struct {
 	logger         logr.Logger
@@ -106,10 +103,8 @@ func (m *Manager) FilterUnusedProbes(target *process.TargetDetails) {
 			}
 		}
 
-		if n := len(inst.Manifest().Symbols); funcsFound != n {
-			if funcsFound > 0 {
-				m.logger.Error(errNotAllFuncsFound, "some of expected functions not found - check instrumented functions", "instrumentation_name", name, "funcs_found", funcsFound, "funcs_expected", n)
-			}
+		if funcsFound == 0 {
+			m.logger.Info("no functions found for probe, removing", "name", name)
 			delete(m.probes, name)
 		}
 	}

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -67,9 +67,9 @@ type Base[BPFObj any, BPFEvent any] struct {
 	// Consts are the constants that need to be injected into the eBPF program
 	// that is run by this Probe.
 	Consts []Const
-	// Uprobes is a mapping from runtime symbols to a UprobeFunc. These define
-	// the eBPF program triggers that need to setup for this Probe.
-	Uprobes map[string]UprobeFunc[BPFObj]
+	// Uprobes is a the collection of eBPF programs that need to be attached to
+	// the target process.
+	Uprobes []Uprobe[BPFObj]
 
 	// ReaderFn is a creation function for a perf.Reader based on the passed
 	// BPFObj related to the probe.
@@ -89,8 +89,8 @@ func (i *Base[BPFObj, BPFEvent]) Manifest() Manifest {
 	structfields := consts(i.Consts).structFields()
 
 	symbols := make([]string, 0, len(i.Uprobes))
-	for s := range i.Uprobes {
-		symbols = append(symbols, s)
+	for _, up := range i.Uprobes {
+		symbols = append(symbols, up.Sym)
 	}
 
 	return NewManifest(i.Name, i.InstrumentedPkg, structfields, symbols)
@@ -146,9 +146,13 @@ func (i *Base[BPFObj, BPFEvent]) buildObj(exec *link.Executable, td *process.Tar
 		return nil, err
 	}
 
-	for symb, f := range i.Uprobes {
-		links, err := f(symb, exec, td, obj)
+	for _, up := range i.Uprobes {
+		links, err := up.Fn(up.Sym, exec, td, obj)
 		if err != nil {
+			if up.Optional {
+				i.Logger.Info("failed to attach optional uprobe", "probe", i.Name, "symbol", up.Sym, "error", err)
+				continue
+			}
 			return nil, err
 		}
 		for _, l := range links {
@@ -217,6 +221,18 @@ func (i *Base[BPFObj, BPFEvent]) Close() {
 // prevent further execution of prog. The Link must be Closed during program
 // shutdown to avoid leaking system resources.
 type UprobeFunc[BPFObj any] func(symbol string, exec *link.Executable, target *process.TargetDetails, obj *BPFObj) ([]link.Link, error)
+
+// Uprobe is an eBPF program that is attached in the entry point and/or the reutrn of a function.
+type Uprobe[BPFObj any] struct {
+	// Sym is the symbol name of the function to attach the eBPF program to.
+	Sym string
+	// Fn is the function that will attach the eBPF program to the function
+	Fn UprobeFunc[BPFObj]
+	// Optional is a boolean flag informing if the Uprobe is optional. If the
+	// Uprobe is optional and fails to attach, the error is logged and
+	// processing continues.
+	Optional bool
+}
 
 // Const is an constant that needs to be injected into an eBPF program.
 type Const interface {

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -226,7 +226,7 @@ type UprobeFunc[BPFObj any] func(symbol string, exec *link.Executable, target *p
 type Uprobe[BPFObj any] struct {
 	// Sym is the symbol name of the function to attach the eBPF program to.
 	Sym string
-	// Fn is the function that will attach the eBPF program to the function
+	// Fn is the function that will attach the eBPF program to the function.
 	Fn UprobeFunc[BPFObj]
 	// Optional is a boolean flag informing if the Uprobe is optional. If the
 	// Uprobe is optional and fails to attach, the error is logged and


### PR DESCRIPTION
* Set the `SetAttributes` uprobe as optional. This is necessary for the case which a span is defined without attributes.  In the current implementation we would not find the `SetAttributes` symbol and remove the probe and kill the entire instrumentation. With this change it makes sense to define that uprobe as Optional.
* Change the `Uprobes` map to slice, as it wasn't used as a map.