### PR TITLE
Make gRPC frame pos deterministic for eBPF verifier

### DIFF
--- a/internal/include/arguments.h
+++ b/internal/include/arguments.h
@@ -23,7 +23,7 @@
 // Injected in init
 volatile const bool is_registers_abi;
 
-void *get_argument_by_reg(struct pt_regs *ctx, int index)
+void __always_inline *get_argument_by_reg(struct pt_regs *ctx, int index)
 {
     switch (index)
     {
@@ -50,7 +50,7 @@ void *get_argument_by_reg(struct pt_regs *ctx, int index)
     }
 }
 
-void *get_argument_by_stack(struct pt_regs *ctx, int index)
+void __always_inline *get_argument_by_stack(struct pt_regs *ctx, int index)
 {
     void *ptr = 0;
     bpf_probe_read(&ptr, sizeof(ptr), (void *)(PT_REGS_SP(ctx) + (index * 8)));

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf/probe.bpf.c
@@ -67,7 +67,7 @@ volatile const u64 frame_fields_pos;
 volatile const u64 frame_stream_id_pod;
 volatile const u64 stream_id_pos;
 volatile const u64 stream_ctx_pos;
-volatile const u64 frame_pos;
+volatile const bool is_new_frame_pos;
 
 // This instrumentation attaches uprobe to the following function:
 // func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Stream, trInfo *traceInfo)
@@ -124,9 +124,15 @@ int uprobe_server_handleStream(struct pt_regs *ctx)
 UPROBE_RETURN(server_handleStream, struct grpc_request_t, grpc_events, events, 4, stream_ctx_pos, false)
 
 // func (d *http2Server) operateHeader(frame *http2.MetaHeadersFrame) error
+// for version 1.60 and above:
+// func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeadersFrame, handle func(*Stream)) error
 SEC("uprobe/http2Server_operateHeader")
 int uprobe_http2Server_operateHeader(struct pt_regs *ctx)
 {
+    u64 frame_pos = 2;
+    if (is_new_frame_pos) {
+        frame_pos = 4;
+    }
     void *frame_ptr = get_argument(ctx, frame_pos);
     struct go_slice header_fields = {};
     bpf_probe_read(&header_fields, sizeof(header_fields), (void *)(frame_ptr + frame_fields_pos));

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -109,11 +109,7 @@ func (c framePosConst) InjectOption(td *process.TargetDetails) (inject.Option, e
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}
 
-	var pos uint64 = 2
-	if ver.GreaterThanOrEqual(paramChangeVer) {
-		pos = 4
-	}
-	return inject.WithKeyValue("frame_pos", pos), nil
+	return inject.WithKeyValue("is_new_frame_pos", ver.GreaterThanOrEqual(paramChangeVer)), nil
 }
 
 func uprobeHandleStream(name string, exec *link.Executable, target *process.TargetDetails, obj *bpfObjects) ([]link.Link, error) {


### PR DESCRIPTION
Following #558, on some kernels the verifier rejected the program because the value being read from `ctx` could not be determined in verification. Changed the passed value from Go to be a flag instead of the position.