### PR TITLE
Mark database/sql uprobes as optional, fix arguments functions

### DIFF
--- a/internal/include/arguments.h
+++ b/internal/include/arguments.h
@@ -23,7 +23,7 @@
 // Injected in init
 volatile const bool is_registers_abi;
 
-void __always_inline *get_argument_by_reg(struct pt_regs *ctx, int index)
+static __always_inline void *get_argument_by_reg(struct pt_regs *ctx, int index)
 {
     switch (index)
     {
@@ -50,14 +50,14 @@ void __always_inline *get_argument_by_reg(struct pt_regs *ctx, int index)
     }
 }
 
-void __always_inline *get_argument_by_stack(struct pt_regs *ctx, int index)
+static __always_inline void *get_argument_by_stack(struct pt_regs *ctx, int index)
 {
     void *ptr = 0;
     bpf_probe_read(&ptr, sizeof(ptr), (void *)(PT_REGS_SP(ctx) + (index * 8)));
     return ptr;
 }
 
-void __always_inline *get_argument(struct pt_regs *ctx, int index)
+static __always_inline void *get_argument(struct pt_regs *ctx, int index)
 {
     if (is_registers_abi)
     {

--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -59,12 +59,14 @@ func New(logger logr.Logger) probe.Probe {
 		},
 		Uprobes: []probe.Uprobe[bpfObjects]{
 			{
-				Sym: "database/sql.(*DB).queryDC",
-				Fn:  uprobeQueryDC,
+				Sym:      "database/sql.(*DB).queryDC",
+				Fn:       uprobeQueryDC,
+				Optional: true,
 			},
 			{
-				Sym: "database/sql.(*DB).execDC",
-				Fn:  uprobeExecDC,
+				Sym:      "database/sql.(*DB).execDC",
+				Fn:       uprobeExecDC,
+				Optional: true,
 			},
 		},
 


### PR DESCRIPTION
Mark both SQL queries and DML-related uprobes as optional to avoid removing the instrumentation entirely if one of them is not found in the binary.