### PR TITLE
Release v0.10.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.10.0-alpha] - 2024-01-02
+
+### Added
+
+- Add `net.host.name`, `net.protocol.name`, `net.peer.name`, and `net.peer.port` attributes to HTTP server spans. ([#470](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/470)
+- Support version `v1.60.1` of `google.golang.org/grpc`. ([#568](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/568))
+
+### Fixed
+
+- Correct the target probe argument positions for the `v1.60.0` and greater versions of the `google.golang.org/grpc` server instrumentation. ([#574](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/574), [#576](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/576))
+- Do not instrument the OpenTelemetry default global implementation if the user has already set a delegate. ([#569](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/569))
+
 ## [v0.9.0-alpha] - 2023-12-14
 
 ### Added
@@ -47,7 +59,6 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Add the `WithTraceExporter` `InstrumentationOption` to configure the trace `SpanExporter` used by an `Instrumentation`. ([#426](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/426))
 - Add HTTP status code attribute to `net/http` server instrumentation. ([#428](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/428))
 - The instrumentation scope now includes the version of the auto-instrumentation project. ([#442](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/442))
-- Add `net.host.name`, `net.protocol.name`, `net.peer.name`, and `net.peer.port` attributes to HTTP server spans. ([#470]https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/470)
 - Add a new `WithSampler` method allowing end-users to provide their own implementation of OpenTelemetry sampler directly through the package API. ([#468](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/468)).
 - Add uprobes to `execDC` in order to instrument SQL DML. ([#475](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/475))
 
@@ -244,7 +255,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.9.0-alpha...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.10.0-alpha...HEAD
+[v0.10.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.10.0-alpha
 [v0.9.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.9.0-alpha
 [v0.8.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.8.0-alpha
 [v0.7.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.7.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
-## [v0.10.0-alpha] - 2024-01-02
+## [v0.10.0-alpha] - 2024-01-03
 
 ### Added
 

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/database/sql",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {
@@ -70,7 +70,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/github.com/gin-gonic/gin",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {
@@ -76,7 +76,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.9.0-alpha"
+              "stringValue": "v0.10.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global",
-            "version": "v0.9.0-alpha"
+            "version": "v0.10.0-alpha"
           },
           "spans": [
             {

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.9.0-alpha"
+	return "v0.10.0-alpha"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   alpha:
-    version: v0.9.0-alpha
+    version: v0.10.0-alpha
     modules:
       - go.opentelemetry.io/auto
 excluded-modules:


### PR DESCRIPTION
### Added

- Add `net.host.name`, `net.protocol.name`, `net.peer.name`, and `net.peer.port` attributes to HTTP server spans. ([#470](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/470)
- Support version `v1.60.1` of `google.golang.org/grpc`. ([#568](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/568))

### Fixed

- Correct the target probe argument positions for the `v1.60.0` and greater versions of the `google.golang.org/grpc` server instrumentation. ([#574](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/574), [#576](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/576))
- Do not instrument the OpenTelemetry default global implementation if the user has already set a delegate. ([#569](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/569))