### PR TITLE
Improve closing and cleaning of running probes

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -155,8 +155,7 @@ func (i *Instrumentation) Run(ctx context.Context) error {
 // Close closes the Instrumentation, cleaning up all used resources.
 func (i *Instrumentation) Close() error {
 	i.analyzer.Close()
-	i.manager.Close()
-	return nil
+	return i.manager.Close()
 }
 
 // InstrumentationOption applies a configuration option to [Instrumentation].

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -48,7 +48,7 @@ type Probe interface {
 	Run(eventsChan chan<- *Event)
 
 	// Close stops the Probe.
-	Close()
+	Close() error
 }
 
 // Base is a base implementation of [Probe].
@@ -201,14 +201,15 @@ func (i *Base[BPFObj, BPFEvent]) processRecord(record perf.Record) (*Event, erro
 }
 
 // Close stops the Probe.
-func (i *Base[BPFObj, BPFEvent]) Close() {
+func (i *Base[BPFObj, BPFEvent]) Close() error {
 	var err error
 	for _, c := range i.closers {
 		err = errors.Join(err, c.Close())
 	}
-	if err != nil {
-		i.Logger.Error(err, "failed to cleanup", "Probe", i.Name)
+	if err == nil {
+		i.Logger.Info("Closed", "Probe", i.Name)
 	}
+	return err
 }
 
 // UprobeFunc is a function that will attach a eBPF program to a perf event


### PR DESCRIPTION
Report errors from closing if exist, change the instrumentation.Close to being synchronous (returning after all the cleanup happened)