### PR TITLE
feat(otelglobal): add support for Span SetName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - Support version `v0.20.0` of `golang.org/x/net`. ([#587](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/587))
 - Support version `v1.20.13` and `v1.21.6` of Go. ([#589](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/589))
+- Add support for manual instrumentation with Span `SetName`. ([#590](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/590))
 
 ### Fixed
 

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -64,10 +64,9 @@ struct {
 // Injected in init
 volatile const u64 tracer_delegate_pos;
 
-
-// span_name_read reads the span name from the provided span_name_ptr and stores the result in
+// read_span_name reads the span name from the provided span_name_ptr and stores the result in
 // span_name.buf.
-static __always_inline void span_name_read(void *span_name_ptr, struct span_name_t *span_name, const u64 span_name_len) {
+static __always_inline void read_span_name(struct span_name_t *span_name, const u64 span_name_len, void *span_name_ptr) {
     const u64 span_name_size = MAX_SPAN_NAME_LEN < span_name_len ? MAX_SPAN_NAME_LEN : span_name_len;
     bpf_probe_read(span_name->buf, span_name_size, span_name_ptr);
 }
@@ -89,7 +88,7 @@ int uprobe_Start(struct pt_regs *ctx) {
     // Getting span name
     void *span_name_ptr = get_argument(ctx, 4);
     u64 span_name_len = (u64)get_argument(ctx, 5);
-    span_name_read(span_name_ptr, &span_name, span_name_len);
+    read_span_name(&span_name, span_name_len, span_name_ptr);
 
     // Save the span name in map to be read once the Start function returns
     void *context_ptr_val = get_Go_context(ctx, 3, 0, true);
@@ -192,7 +191,7 @@ int uprobe_SetName(struct pt_regs *ctx) {
     u64 span_name_len = (u64)span_name_len_ptr;
     struct span_name_t span_name = {0};
 
-    span_name_read(span_name_ptr, &span_name, span_name_len);
+    read_span_name(&span_name, span_name_len, span_name_ptr);
     span->span_name = span_name;
     bpf_map_update_elem(&active_spans_by_span_ptr, &non_recording_span_ptr, span, 0);
     

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -64,6 +64,14 @@ struct {
 // Injected in init
 volatile const u64 tracer_delegate_pos;
 
+
+// span_name_read reads the span name from the provided span_name_ptr and stores the result in
+// span_name.buf.
+static __always_inline void span_name_read(void *span_name_ptr, struct span_name_t span_name, const u64 span_name_len) {
+    const u64 span_name_size = MAX_SPAN_NAME_LEN < span_name_len ? MAX_SPAN_NAME_LEN : span_name_len;
+    bpf_probe_read(span_name.buf, span_name_size, span_name_ptr);
+}
+
 // This instrumentation attaches uprobe to the following function:
 // func (t *tracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span)
 // https://github.com/open-telemetry/opentelemetry-go/blob/98b32a6c3a87fbee5d34c063b9096f416b250897/internal/global/trace.go#L149
@@ -81,8 +89,7 @@ int uprobe_Start(struct pt_regs *ctx) {
     // Getting span name
     void *span_name_ptr = get_argument(ctx, 4);
     u64 span_name_len = (u64)get_argument(ctx, 5);
-    u64 span_name_size = MAX_SPAN_NAME_LEN < span_name_len ? MAX_SPAN_NAME_LEN : span_name_len;
-    bpf_probe_read(span_name.buf, span_name_size, span_name_ptr);
+    span_name_read(span_name_ptr, span_name, span_name_len);
 
     // Save the span name in map to be read once the Start function returns
     void *context_ptr_val = get_Go_context(ctx, 3, 0, true);
@@ -162,6 +169,35 @@ int uprobe_SetAttributes(struct pt_regs *ctx) {
     return 0;
 }
 
+// This instrumentation attaches uprobe to the following function:
+// func (nonRecordingSpan) SetName(string)
+SEC("uprobe/SetName")
+int uprobe_SetName(struct pt_regs *ctx) {
+    void *non_recording_span_ptr = get_argument(ctx, 1);
+    struct otel_span_t *span = bpf_map_lookup_elem(&active_spans_by_span_ptr, &non_recording_span_ptr);
+    if (span == NULL) {
+        return 0;
+    }
+
+    void *span_name_ptr = get_argument(ctx, 4);
+    if (span_name_ptr == NULL) {
+        return 0;
+    }
+
+    void *span_name_len_ptr = get_argument(ctx, 5);
+    if (span_name_len_ptr == NULL) {
+        return 0;
+    }
+
+    u64 span_name_len = (u64)span_name_len_ptr;
+    struct span_name_t span_name = {0};
+
+    span_name_read(span_name_ptr, span_name, span_name_len);
+    span->span_name = span_name;
+    bpf_map_update_elem(&active_spans_by_span_ptr, &non_recording_span_ptr, span, 0);
+    
+    return 0;
+}
 
 // This instrumentation attaches uprobe to the following function:
 // func (*nonRecordingSpan) End(...trace.SpanEndOption)

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -179,12 +179,12 @@ int uprobe_SetName(struct pt_regs *ctx) {
         return 0;
     }
 
-    void *span_name_ptr = get_argument(ctx, 4);
+    void *span_name_ptr = get_argument(ctx, 2);
     if (span_name_ptr == NULL) {
         return 0;
     }
 
-    void *span_name_len_ptr = get_argument(ctx, 5);
+    void *span_name_len_ptr = get_argument(ctx, 3);
     if (span_name_len_ptr == NULL) {
         return 0;
     }

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_bpfel_arm64.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_bpfel_arm64.go
@@ -83,6 +83,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	UprobeEnd           *ebpf.ProgramSpec `ebpf:"uprobe_End"`
 	UprobeSetAttributes *ebpf.ProgramSpec `ebpf:"uprobe_SetAttributes"`
+	UprobeSetName       *ebpf.ProgramSpec `ebpf:"uprobe_SetName"`
 	UprobeStart         *ebpf.ProgramSpec `ebpf:"uprobe_Start"`
 	UprobeStartReturns  *ebpf.ProgramSpec `ebpf:"uprobe_Start_Returns"`
 }
@@ -149,6 +150,7 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	UprobeEnd           *ebpf.Program `ebpf:"uprobe_End"`
 	UprobeSetAttributes *ebpf.Program `ebpf:"uprobe_SetAttributes"`
+	UprobeSetName       *ebpf.Program `ebpf:"uprobe_SetName"`
 	UprobeStart         *ebpf.Program `ebpf:"uprobe_Start"`
 	UprobeStartReturns  *ebpf.Program `ebpf:"uprobe_Start_Returns"`
 }
@@ -157,6 +159,7 @@ func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.UprobeEnd,
 		p.UprobeSetAttributes,
+		p.UprobeSetName,
 		p.UprobeStart,
 		p.UprobeStartReturns,
 	)

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_bpfel_x86.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_bpfel_x86.go
@@ -83,6 +83,7 @@ type bpfSpecs struct {
 type bpfProgramSpecs struct {
 	UprobeEnd           *ebpf.ProgramSpec `ebpf:"uprobe_End"`
 	UprobeSetAttributes *ebpf.ProgramSpec `ebpf:"uprobe_SetAttributes"`
+	UprobeSetName       *ebpf.ProgramSpec `ebpf:"uprobe_SetName"`
 	UprobeStart         *ebpf.ProgramSpec `ebpf:"uprobe_Start"`
 	UprobeStartReturns  *ebpf.ProgramSpec `ebpf:"uprobe_Start_Returns"`
 }
@@ -149,6 +150,7 @@ func (m *bpfMaps) Close() error {
 type bpfPrograms struct {
 	UprobeEnd           *ebpf.Program `ebpf:"uprobe_End"`
 	UprobeSetAttributes *ebpf.Program `ebpf:"uprobe_SetAttributes"`
+	UprobeSetName       *ebpf.Program `ebpf:"uprobe_SetName"`
 	UprobeStart         *ebpf.Program `ebpf:"uprobe_Start"`
 	UprobeStartReturns  *ebpf.Program `ebpf:"uprobe_Start_Returns"`
 }
@@ -157,6 +159,7 @@ func (p *bpfPrograms) Close() error {
 	return _BpfClose(
 		p.UprobeEnd,
 		p.UprobeSetAttributes,
+		p.UprobeSetName,
 		p.UprobeStart,
 		p.UprobeStartReturns,
 	)

--- a/internal/test/e2e/otelglobal/main.go
+++ b/internal/test/e2e/otelglobal/main.go
@@ -31,11 +31,19 @@ func innerFunction(ctx context.Context) {
 	span.SetAttributes(attribute.String("inner.key", "inner.value"))
 }
 
+func setNameOverride(ctx context.Context) {
+	_, span := tracer.Start(ctx, "SetNameOriginal")
+	defer span.End()
+
+	span.SetName("SetNameOverride")
+}
+
 func createMainSpan(ctx context.Context) {
 	ctx, span := tracer.Start(ctx, "parent")
 	defer span.End()
 
 	innerFunction(ctx)
+	setNameOverride(ctx)
 
 	intAttr := attribute.Int("int_key", 42)
 	strAttr := attribute.String("string_key", "forty-two")

--- a/internal/test/e2e/otelglobal/main.go
+++ b/internal/test/e2e/otelglobal/main.go
@@ -29,13 +29,7 @@ func innerFunction(ctx context.Context) {
 	defer span.End()
 
 	span.SetAttributes(attribute.String("inner.key", "inner.value"))
-}
-
-func setNameOverride(ctx context.Context) {
-	_, span := tracer.Start(ctx, "SetNameOriginal")
-	defer span.End()
-
-	span.SetName("SetNameOverride")
+	span.SetName("child override")
 }
 
 func createMainSpan(ctx context.Context) {
@@ -43,7 +37,6 @@ func createMainSpan(ctx context.Context) {
 	defer span.End()
 
 	innerFunction(ctx)
-	setNameOverride(ctx)
 
 	intAttr := attribute.Int("int_key", 42)
 	strAttr := attribute.String("string_key", "forty-two")

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -66,6 +66,15 @@
               "traceId": "xxxxx"
             },
             {
+              "attributes": [],
+              "kind": 3,
+              "name": "SetNameOverride",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
               "attributes": [
                 {
                   "key": "int_key",

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -59,16 +59,7 @@
                 }
               ],
               "kind": 3,
-              "name": "child",
-              "parentSpanId": "xxxxx",
-              "spanId": "xxxxx",
-              "status": {},
-              "traceId": "xxxxx"
-            },
-            {
-              "attributes": [],
-              "kind": 3,
-              "name": "SetNameOverride",
+              "name": "child override",
               "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},

--- a/internal/test/e2e/otelglobal/verify.bats
+++ b/internal/test/e2e/otelglobal/verify.bats
@@ -35,7 +35,7 @@ SCOPE="go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global"
 }
 
 @test "server :: trace ID present and valid in child span" {
-  trace_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child\")" | jq ".traceId")
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child override\")" | jq ".traceId")
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
@@ -45,7 +45,7 @@ SCOPE="go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global"
 }
 
 @test "server :: span ID present and valid in child span" {
-  trace_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child\")" | jq ".spanId")
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child override\")" | jq ".spanId")
   assert_regex "$trace_id" ${MATCH_A_SPAN_ID}
 }
 
@@ -55,13 +55,8 @@ SCOPE="go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global"
 }
 
 @test "server :: parent span ID present and valid in child span" {
-  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child\")" | jq ".parentSpanId")
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"child override\")" | jq ".parentSpanId")
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
-}
-
-@test "server :: span set name overrides original span name" {
-  span_set_name_override=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"SetNameOverride\")" | jq ".traceId")
-  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "server :: expected (redacted) trace output" {

--- a/internal/test/e2e/otelglobal/verify.bats
+++ b/internal/test/e2e/otelglobal/verify.bats
@@ -59,6 +59,11 @@ SCOPE="go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global"
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 
+@test "server :: span set name overrides original span name" {
+  span_set_name_override=$(spans_from_scope_named ${SCOPE} | jq "select(.name == \"SetNameOverride\")" | jq ".traceId")
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+}
+
 @test "server :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""


### PR DESCRIPTION
Adds support for setting a span name via manual instrumentation, as described in #542.

NOTE: this is my first PR in this repo. Open to any and all suggestions 🙂 