### PR TITLE
Increase memlock limit before instrumenting

### DIFF
--- a/internal/pkg/process/allocate.go
+++ b/internal/pkg/process/allocate.go
@@ -16,6 +16,7 @@ package process
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 
@@ -78,6 +79,11 @@ func remoteAllocate(logger logr.Logger, pid int, mapSize uint64) (uint64, error)
 	addr, err := program.Mmap(mapSize, uint64(fd))
 	if err != nil {
 		return 0, err
+	}
+	if addr == math.MaxUint64 {
+		// On success, mmap() returns a pointer to the mapped area.
+		// On error, the value MAP_FAILED (that is, (void *) -1) is returned
+		return 0, fmt.Errorf("mmap MAP_FAILED")
 	}
 
 	err = program.Madvise(addr, mapSize)

--- a/internal/pkg/process/allocate.go
+++ b/internal/pkg/process/allocate.go
@@ -67,6 +67,13 @@ func remoteAllocate(logger logr.Logger, pid int, mapSize uint64) (uint64, error)
 			logger.Error(err, "Failed to detach ptrace", "pid", pid)
 		}
 	}()
+
+	if err := program.SetMemLockInfinity(); err != nil {
+		logger.Error(err, "Failed to set memlock on process")
+	} else {
+		logger.Info("Set memlock on process successfully")
+	}
+
 	fd := -1
 	addr, err := program.Mmap(mapSize, uint64(fd))
 	if err != nil {

--- a/internal/pkg/process/ptrace/ptrace_linux.go
+++ b/internal/pkg/process/ptrace/ptrace_linux.go
@@ -221,7 +221,7 @@ func (p *TracedProgram) Step() error {
 
 // SetMemLockInfinity sets the memlock rlimit to infinity.
 func (p *TracedProgram) SetMemLockInfinity() error {
-	// pid 0 affects the current process. Requires CAP_SYS_RESOURCE.
+	// Requires CAP_SYS_RESOURCE.
 	newLimit := unix.Rlimit{Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY}
 	if err := unix.Prlimit(p.pid, unix.RLIMIT_MEMLOCK, &newLimit, nil); err != nil {
 		return fmt.Errorf("failed to set memlock rlimit: %w", err)


### PR DESCRIPTION
This PR fixes a bug on some Linux distros where the lock limit may be lower than the allocated memory.