### PR TITLE
Reduce flakiness, and print logs in failures

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -61,7 +61,13 @@ jobs:
       - name: Helm install collector
         run: helm install test -f .github/workflows/e2e/k8s/collector-helm-values.yml opentelemetry-helm-charts/charts/opentelemetry-collector
       - name: check collector status
+        # The loop is needed if the pod is not created yet
+        # once https://github.com/kubernetes/kubectl/issues/1516 is fixed we can remove the loop
         run: |
+          while : ; do
+            kubectl get pod/test-opentelemetry-collector-0 && break
+            sleep 5
+          done
           kubectl wait --for=condition=Ready --timeout=60s pod/test-opentelemetry-collector-0
       - name: start sample job
         run: |
@@ -74,13 +80,13 @@ jobs:
         run: |
           kubectl cp -c filecp default/test-opentelemetry-collector-0:tmp/trace.json ./internal/test/e2e/${{ matrix.library }}/traces-orig.json
           rm -f ./internal/test/e2e/${{ matrix.library }}/traces.json
-        if: steps.job-status.outcome == 'success'
+        if: always() && steps.job-status.outcome == 'success'
       - name: print auto-instrumentation logs
         run: |
-          kubectl logs -l app=sample -c auto-instrumentation
+          kubectl logs -l app=sample -c auto-instrumentation --tail=300
           exit 1
-        if: steps.job-status.outcome == 'failure'
+        if: always() && steps.job-status.outcome == 'failure'
       - name: verify output and redact to traces.json
         run: |
           bats ./internal/test/e2e/${{ matrix.library }}/verify.bats
-        if: steps.job-status.outcome == 'success'
+        if: always() && steps.job-status.outcome == 'success'


### PR DESCRIPTION
* The logs were not printed if the workflow fails: https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions.
* Waiting for the collector pod to be ready can be flaky sometimes because of https://github.com/kubernetes/kubectl/issues/1516
