### PR TITLE
Don't call manager.Close() when Analyze() fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Fixed
 
-- Don't call manager.Close() when Analyze() fails. ([#638](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/638))
+- Don't call `manager.Close()` when `Analyze()` fails. ([#638](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/638))
 
 ## [v0.10.1-alpha] - 2024-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't call manager.Close() when Analyze() fails. ([#638](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/638))
+
 ## [v0.10.1-alpha] - 2024-01-10
 
 ### Added

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -121,7 +121,6 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 
 	td, err := pa.Analyze(pid, mngr.GetRelevantFuncs())
 	if err != nil {
-		mngr.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
There's no need to call `manager.Close()` at this point because the manager is not running yet. Doing so actually causes it to hang because of waiting for [this channel](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/e00e32a2b582f7a30f9f8b44cbd3db837815d3b2/internal/pkg/instrumentation/manager.go#L211) added in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/586.

This also prevents errors from propagating up as seen in https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/636