### PR TITLE
Avoid using runtime.NumCPU to get the number of CPUs on the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Close `proc` file when done discovering PID. ([#649](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/649))
 - Use `debug` packages to parse Go and modules' versions. ([#653](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/653))
 - Clean up warn in otelglobal `SetStatus()` when grabbing the status code. ([#675](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/675))
+- Avoid using runtime.NumCPU to get the number of CPUs on the system before remote mmap ([#680](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/680))
 
 ## [v0.10.1-alpha] - 2024-01-10
 

--- a/internal/include/alloc.h
+++ b/internal/include/alloc.h
@@ -22,7 +22,7 @@
 #define MIN_BUFFER_SIZE 1
 
 // Injected in init
-volatile const u32 total_cpus;
+volatile const u64 total_cpus;
 volatile const u64 start_addr;
 volatile const u64 end_addr;
 
@@ -108,6 +108,12 @@ static __always_inline void *write_target_data(void *data, s32 size)
     {
         target += dist_to_next_page;
     }
+    u64 target_u = (u64)target;
+    if (target_u > end_addr || target_u < start_addr) {
+        bpf_printk("TARGET ADDRESS IS OUT OF BOUNDS: 0x%llx", target);
+        return NULL;
+    }
+
     long success = bpf_probe_write_user(target, data, size);
     if (success == 0)
     {

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"runtime"
 
 	"github.com/cilium/ebpf"
 	"github.com/hashicorp/go-version"
@@ -34,8 +33,6 @@ var (
 
 	offsets     = structfield.NewIndex()
 	errNotFound = errors.New("offset not found")
-
-	nCPU = uint32(runtime.NumCPU())
 )
 
 const (
@@ -114,7 +111,7 @@ func WithRegistersABI(value bool) Option {
 // "start_addr", and "end_addr".
 func WithAllocationDetails(details process.AllocationDetails) Option {
 	return option{
-		keyTotalCPUs: nCPU,
+		keyTotalCPUs: details.NumCPU,
 		keyStartAddr: details.StartAddr,
 		keyEndAddr:   details.EndAddr,
 	}

--- a/internal/pkg/inject/consts_test.go
+++ b/internal/pkg/inject/consts_test.go
@@ -37,7 +37,7 @@ func TestWithRegistersABI(t *testing.T) {
 }
 
 func TestWithAllocationDetails(t *testing.T) {
-	const start, end uint64 = 1, 2
+	const start, end, nCPU uint64 = 1, 2, 3
 	details := process.AllocationDetails{
 		StartAddr: start,
 		EndAddr:   end,
@@ -51,8 +51,8 @@ func TestWithAllocationDetails(t *testing.T) {
 	require.Contains(t, got, keyEndAddr)
 
 	v := got[keyTotalCPUs]
-	require.IsType(t, *(new(uint32)), v)
-	assert.Equal(t, nCPU, v.(uint32))
+	require.IsType(t, *(new(uint64)), v)
+	assert.Equal(t, nCPU, v.(uint64))
 
 	v = got[keyStartAddr]
 	require.IsType(t, *(new(uint64)), v)

--- a/internal/pkg/inject/consts_test.go
+++ b/internal/pkg/inject/consts_test.go
@@ -41,6 +41,7 @@ func TestWithAllocationDetails(t *testing.T) {
 	details := process.AllocationDetails{
 		StartAddr: start,
 		EndAddr:   end,
+		NumCPU:    nCPU,
 	}
 
 	opts := []Option{WithAllocationDetails(details)}


### PR DESCRIPTION
`runtime.NumCPU` doc states:

> NumCPU returns the number of logical CPUs usable by the current process

This is problematic when the probed process is configured to run on a subset of the available CPUs.
In addition, we perform the above call for the agent process, so even if the probed process has some configuration for this, we won't see it.
This PR replaces this call with querying the relevant files to get the number of CPUs available in the system.
Adding a boundary check in `write_target_data` to ensure that we are not writing to an un-mapped address if something goes wrong.