### PR TITLE
Reset the /proc offset after a failed attempt to find pid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Close `proc` file when done discovering PID. ([#649](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/649))
 - Use `debug` packages to parse Go and modules' versions. ([#653](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/653))
 - Clean up warn in otelglobal `SetStatus()` when grabbing the status code. ([#675](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/675))
+- Reset `proc` offset after a failed iteration. ([#681](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/681))
 
 ## [v0.10.1-alpha] - 2024-01-10
 

--- a/internal/pkg/process/discover.go
+++ b/internal/pkg/process/discover.go
@@ -82,6 +82,12 @@ func (a *Analyzer) DiscoverProcessID(target *TargetArgs) (int, error) {
 			} else {
 				a.logger.Error(err, "error while searching for process", "exe_path", target.ExePath)
 			}
+
+			// Reset the file offset for next iteration
+			_, err = proc.Seek(0, 0)
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 }


### PR DESCRIPTION
Following #649, since we are using the same file pointer,  need to reset the offset after a failed attempt to find the pid. The current code will reach EOF the first time and will read from the same offset next time (which can cause a miss to find the target pid).