### PR TITLE
Delay map cleanup in bpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Clean up warn in otelglobal `SetStatus()` when grabbing the status code. ([#675](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/675))
 - Reset `proc` offset after a failed iteration. ([#681](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/681))
 - Avoid using runtime.NumCPU to get the number of CPUs on the system before remote mmap ([#680](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/680))
+- Cleanup eBPF maps only when we stop using the memory ([#682](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/682))
 
 ## [v0.10.1-alpha] - 2024-01-10
 

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
@@ -236,7 +236,6 @@ int uprobe_Transport_roundTrip_Returns(struct pt_regs *ctx) {
         bpf_printk("probe_Transport_roundTrip_Returns: entry_state is NULL");
         return 0;
     }
-    bpf_map_delete_elem(&http_events, &key);
 
     if (is_register_abi()) {
         // Getting the returned response
@@ -249,5 +248,7 @@ int uprobe_Transport_roundTrip_Returns(struct pt_regs *ctx) {
 
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, http_req_span, sizeof(*http_req_span));
     stop_tracking_span(&http_req_span->sc, &http_req_span->psc);
+
+    bpf_map_delete_elem(&http_events, &key);
     return 0;
 }


### PR DESCRIPTION
While looking at how to best add the follow-up code for detecting kernel lockdown, I noticed a few places where delete in BPF maps is done before we actually stop using the map memory. While the chances of collision in BPF maps are small, it's possible that another thread with a goroutine hashes into the same memory location, before we stop using the memory. This PR moves few deletes into a safe spot.