### PR TITLE
Add HTTP client attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - Test build using [Go 1.22]. (#672)
 - Base Dockerfile and build caching ([#683](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/683))
+- Add `server.address`, `server.port` and `network.protocol.version` to HTTP client spans ([696](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/696))
 
 ### Fixed
 

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
@@ -6,7 +6,7 @@
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
-#define MAX_HOSTNAME_SIZE 128
+#define MAX_HOSTNAME_SIZE 256
 #define MAX_PROTO_SIZE 8
 #define MAX_PATH_SIZE 100
 #define MAX_METHOD_SIZE 10

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
@@ -6,6 +6,8 @@
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
+#define MAX_HOSTNAME_SIZE 128
+#define MAX_PROTO_SIZE 8
 #define MAX_PATH_SIZE 100
 #define MAX_METHOD_SIZE 10
 #define W3C_KEY_LENGTH 11
@@ -14,6 +16,8 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 struct http_request_t {
     BASE_SPAN_PROPERTIES
+    char host[MAX_HOSTNAME_SIZE];
+    char proto[MAX_PROTO_SIZE];
     u64 status_code;
     char method[MAX_METHOD_SIZE];
     char path[MAX_PATH_SIZE];
@@ -53,6 +57,8 @@ volatile const u64 headers_ptr_pos;
 volatile const u64 ctx_ptr_pos;
 volatile const u64 buckets_ptr_pos;
 volatile const u64 status_code_pos;
+volatile const u64 request_host_pos;
+volatile const u64 request_proto_pos;
 
 static __always_inline long inject_header(void* headers_ptr, struct span_context* propagated_ctx) {
     // Read the key-value count - this field must be the first one in the hmap struct as documented in src/runtime/map.go
@@ -207,6 +213,16 @@ int uprobe_Transport_roundTrip(struct pt_regs *ctx) {
     if (!get_go_string_from_user_ptr((void *)(url_ptr+path_ptr_pos), httpReq->path, sizeof(httpReq->path))) {
         bpf_printk("uprobe_Transport_roundTrip: Failed to get path from Request.URL");
         return 0;
+    }
+
+    // get host from Request
+    if (!get_go_string_from_user_ptr((void *)(req_ptr+request_host_pos), httpReq->host, sizeof(httpReq->host))) {
+        bpf_printk("uprobe_Transport_roundTrip: Failed to get host from Request");
+    }
+
+    // get proto from Request
+    if (!get_go_string_from_user_ptr((void *)(req_ptr+request_proto_pos), httpReq->proto, sizeof(httpReq->proto))) {
+        bpf_printk("uprobe_Transport_roundTrip: Failed to get proto from Request");
     }
 
     // get headers from Request

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_arm64.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_arm64.go
@@ -17,6 +17,8 @@ type bpfHttpRequestT struct {
 	EndTime    uint64
 	Sc         bpfSpanContext
 	Psc        bpfSpanContext
+	Host       [128]int8
+	Proto      [8]int8
 	StatusCode uint64
 	Method     [10]int8
 	Path       [100]int8

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_arm64.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_arm64.go
@@ -17,7 +17,7 @@ type bpfHttpRequestT struct {
 	EndTime    uint64
 	Sc         bpfSpanContext
 	Psc        bpfSpanContext
-	Host       [128]int8
+	Host       [256]int8
 	Proto      [8]int8
 	StatusCode uint64
 	Method     [10]int8

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_x86.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_x86.go
@@ -17,6 +17,8 @@ type bpfHttpRequestT struct {
 	EndTime    uint64
 	Sc         bpfSpanContext
 	Psc        bpfSpanContext
+	Host       [128]int8
+	Proto      [8]int8
 	StatusCode uint64
 	Method     [10]int8
 	Path       [100]int8

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_x86.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_bpfel_x86.go
@@ -17,7 +17,7 @@ type bpfHttpRequestT struct {
 	EndTime    uint64
 	Sc         bpfSpanContext
 	Psc        bpfSpanContext
-	Host       [128]int8
+	Host       [256]int8
 	Proto      [8]int8
 	StatusCode uint64
 	Method     [10]int8

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -150,7 +150,7 @@ func uprobeRoundTrip(name string, exec *link.Executable, target *process.TargetD
 // request-response.
 type event struct {
 	context.BaseSpanProperties
-	Host       [128]byte
+	Host       [256]byte
 	Proto      [8]byte
 	StatusCode uint64
 	Method     [10]byte

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -144,6 +144,24 @@
                   "value": {
                     "intValue": "200"
                   }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
                 }
               ],
               "kind": 3,

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -150,6 +150,24 @@
                   "value": {
                     "intValue": "200"
                   }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
                 }
               ],
               "kind": 3,

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -120,6 +120,24 @@
                   "value": {
                     "intValue": "200"
                   }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
                 }
               ],
               "kind": 3,

--- a/internal/test/e2e/nethttp/verify.bats
+++ b/internal/test/e2e/nethttp/verify.bats
@@ -66,11 +66,6 @@ SCOPE="go.opentelemetry.io/auto/net/http"
   assert_equal "$client_span_id" "$server_parent_span_id"
 }
 
-@test "server :: expected (redacted) trace output" {
-  redact_json
-  assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
-}
-
 @test "server :: includes net.host.name attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"net.host.name\").value.stringValue")
   assert_equal "$result" '"localhost:8080"'
@@ -84,4 +79,24 @@ SCOPE="go.opentelemetry.io/auto/net/http"
 @test "server :: includes net.peer.name attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"net.peer.name\").value.stringValue")
   assert_equal "$result" '"::1"'
+}
+
+@test "client :: includes server.address attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"server.address\").value.stringValue")
+  assert_equal "$result" '"localhost"'
+}
+
+@test "client :: includes server.port attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"server.port\").value.intValue")
+  assert_equal "$result" '"8080"'
+}
+
+@test "client :: includes network.protocol.version attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"network.protocol.version\").value.stringValue")
+  assert_equal "$result" '"1.1"'
+}
+
+@test "client, server :: expected (redacted) trace output" {
+  redact_json
+  assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""
 }

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -120,6 +120,24 @@
                   "value": {
                     "intValue": "200"
                   }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
                 }
               ],
               "kind": 3,

--- a/internal/test/e2e/nethttp_custom/verify.bats
+++ b/internal/test/e2e/nethttp_custom/verify.bats
@@ -76,6 +76,21 @@ SCOPE="go.opentelemetry.io/auto/net/http"
   assert_equal "$result" '"::1"'
 }
 
+@test "client :: includes server.address attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"server.address\").value.stringValue")
+  assert_equal "$result" '"localhost"'
+}
+
+@test "client :: includes server.port attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"server.port\").value.intValue")
+  assert_equal "$result" '"8080"'
+}
+
+@test "client :: includes network.protocol.version attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"network.protocol.version\").value.stringValue")
+  assert_equal "$result" '"1.1"'
+}
+
 @test "server :: expected (redacted) trace output" {
   redact_json
   assert_equal "$(git --no-pager diff ${BATS_TEST_DIRNAME}/traces.json)" ""


### PR DESCRIPTION
Adding:
* `server.address`
*  `server.port `
* `network.protocol.version`

These are consistent with the latest [semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client)