### PR TITLE
Prerelease v0.11.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Reset `proc` offset after a failed iteration. ([#681](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/681))
 - Avoid using runtime.NumCPU to get the number of CPUs on the system before remote mmap ([#680](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/680))
 - Cleanup eBPF maps only when we stop using the memory ([#682](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/682))
+- Fix start offset calculation in mmaped memory area ([#738](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/738))
 
 ## [v0.10.1-alpha] - 2024-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
-### Added
-
-### Fixed
 
 ## [v0.11.0-alpha] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Added
 
+### Fixed
+
+## [v0.11.0-alpha] - 2024-03-26
+
+### Added
+
 - Test build using [Go 1.22]. (#672)
 - Base Dockerfile and build caching ([#683](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/683))
 - Add `server.address`, `server.port` and `network.protocol.version` to HTTP client spans ([#696](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/696))
@@ -287,7 +293,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.10.1-alpha...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.11.0-alpha...HEAD
+[v0.10.1-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.11.0-alpha
 [v0.10.1-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.10.1-alpha
 [v0.10.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.10.0-alpha
 [v0.9.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.9.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,7 +294,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
 [Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.11.0-alpha...HEAD
-[v0.10.1-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.11.0-alpha
+[v0.11.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.11.0-alpha
 [v0.10.1-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.10.1-alpha
 [v0.10.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.10.0-alpha
 [v0.9.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.9.0-alpha

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,14 @@
 
 ## Release PR
 
-First, decide which module sets will be released and update their versions
+Fetch the latest `main` branch from upstream and checkout a new branch for your prerelease PR:
+
+```
+git fetch origin
+git checkout origin/main -b prerelease
+```
+
+Then, decide which module sets will be released and update their versions
 in `versions.yaml`.  Commit this change to a new branch.
 
 1. Run the `prerelease` make target. It creates a branch
@@ -11,6 +18,8 @@ in `versions.yaml`.  Commit this change to a new branch.
     ```
     make prerelease MODSET=<module set>
     ```
+    
+    `<module set>` refers to the [set name in `versions.yaml`](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/f18c1b2e0702d8ac31699c5e923590d714d0c1dc/versions.yaml#L16)
 
 2. Verify the changes.
 
@@ -35,8 +44,10 @@ in `versions.yaml`.  Commit this change to a new branch.
 
    - Move all the `Unreleased` changes into a new section following the title scheme (`[<new tag>] - <date of release>`).
    - Update all the appropriate links at the bottom.
+   
+4. Update [`version.go`](version.go) with the latest release version.
 
-4. Push the changes to upstream and create a Pull Request on GitHub.
+5. Push the changes to your branch and create a Pull Request on GitHub.
     Be sure to include the curated changes from the [Changelog](./CHANGELOG.md) in the description.
 
 ## Tag

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/database/sql",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {
@@ -70,7 +70,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/github.com/gin-gonic/gin",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {
@@ -76,7 +76,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -30,7 +30,7 @@
           {
             "key": "telemetry.auto.version",
             "value": {
-              "stringValue": "v0.10.1-alpha"
+              "stringValue": "v0.11.0-alpha"
             }
           },
           {
@@ -46,7 +46,7 @@
         {
           "scope": {
             "name": "go.opentelemetry.io/auto/go.opentelemetry.io/otel/internal/global",
-            "version": "v0.10.1-alpha"
+            "version": "v0.11.0-alpha"
           },
           "spans": [
             {

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.10.1-alpha"
+	return "v0.11.0-alpha"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   alpha:
-    version: v0.10.1-alpha
+    version: v0.11.0-alpha
     modules:
       - go.opentelemetry.io/auto
 excluded-modules:


### PR DESCRIPTION
### Added

- Test build using [Go 1.22]. (#672)
- Base Dockerfile and build caching ([#683](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/683))
- Add `server.address`, `server.port` and `network.protocol.version` to HTTP client spans ([#696](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/696))
- Update http server attributes to latest semantic conventions ([#708](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/708))
### Fixed
- Don't call `manager.Close()` when `Analyze()` fails. ([#638](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/638))
- Close `proc` file when done discovering PID. ([#649](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/649))
- Use `debug` packages to parse Go and modules' versions. ([#653](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/653))
- Clean up warn in otelglobal `SetStatus()` when grabbing the status code. ([#675](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/675))
- Reset `proc` offset after a failed iteration. ([#681](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/681))
- Avoid using runtime.NumCPU to get the number of CPUs on the system before remote mmap ([#680](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/680))
- Cleanup eBPF maps only when we stop using the memory ([#682](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/682))

[Go 1.22]: https://go.dev/doc/go1.22