### PR TITLE
Remove high cardinality path from HTTP client span name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Fixed
+- Change HTTP client span name to `{http.request.method}` ([#775](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/775))
+
 
 ## [v0.12.0-alpha] - 2024-04-10
 
@@ -29,7 +32,6 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - Handle Ctrl-C signal while searching for the target PID ([#731](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/731))
 - Pass PID to `UprobeOptions` ([#742](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/742))
-- Change HTTP client span name to `{http.request.method}` ([#775](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/775))
 
 ## [v0.11.0-alpha] - 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - Handle Ctrl-C signal while searching for the target PID ([#731](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/731))
 - Pass PID to `UprobeOptions` ([#742](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/742))
+- Change HTTP client span name to `{http.request.method}` ([#775](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/775))
 
 ## [v0.11.0-alpha] - 2024-03-26
 

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -203,7 +203,7 @@ func convertEvent(e *event) *probe.SpanEvent {
 	}
 
 	return &probe.SpanEvent{
-		SpanName:          path,
+		SpanName:          method,
 		StartTime:         int64(e.StartTime),
 		EndTime:           int64(e.EndTime),
 		SpanContext:       &sc,

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -171,7 +171,7 @@
                 }
               ],
               "kind": 3,
-              "name": "/query_db",
+              "name": "GET",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -177,7 +177,7 @@
                 }
               ],
               "kind": 3,
-              "name": "/hello-gin",
+              "name": "GET",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -147,7 +147,7 @@
                 }
               ],
               "kind": 3,
-              "name": "/hello",
+              "name": "GET",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/internal/test/e2e/nethttp/verify.bats
+++ b/internal/test/e2e/nethttp/verify.bats
@@ -14,6 +14,11 @@ SCOPE="go.opentelemetry.io/auto/net/http"
   assert_equal "$result" '"GET"'
 }
 
+@test "client :: emits a span name '{http.request.method}' (per semconv)" {
+  result=$(client_span_names_for ${SCOPE})
+  assert_equal "$result" '"GET"'
+}
+
 @test "server :: includes http.request.method attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"http.request.method\").value.stringValue")
   assert_equal "$result" '"GET"'
@@ -21,6 +26,11 @@ SCOPE="go.opentelemetry.io/auto/net/http"
 
 @test "server :: includes url.path attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"url.path\").value.stringValue")
+  assert_equal "$result" '"/hello"'
+}
+
+@test "client :: includes url.path attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"url.path\").value.stringValue")
   assert_equal "$result" '"/hello"'
 }
 

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -147,7 +147,7 @@
                 }
               ],
               "kind": 3,
-              "name": "/hello",
+              "name": "GET",
               "parentSpanId": "",
               "spanId": "xxxxx",
               "status": {},

--- a/internal/test/e2e/nethttp_custom/verify.bats
+++ b/internal/test/e2e/nethttp_custom/verify.bats
@@ -14,6 +14,11 @@ SCOPE="go.opentelemetry.io/auto/net/http"
   assert_equal "$result" '"GET"'
 }
 
+@test "client :: emits a span name '{http.request.method}' (per semconv)" {
+  result=$(client_span_names_for ${SCOPE})
+  assert_equal "$result" '"GET"'
+}
+
 @test "server :: includes http.request.method attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"http.request.method\").value.stringValue")
   assert_equal "$result" '"GET"'
@@ -21,6 +26,11 @@ SCOPE="go.opentelemetry.io/auto/net/http"
 
 @test "server :: includes url.path attribute" {
   result=$(server_span_attributes_for ${SCOPE} | jq "select(.key == \"url.path\").value.stringValue")
+  assert_equal "$result" '"/hello"'
+}
+
+@test "client :: includes url.path attribute" {
+  result=$(client_span_attributes_for ${SCOPE} | jq "select(.key == \"url.path\").value.stringValue")
   assert_equal "$result" '"/hello"'
 }
 


### PR DESCRIPTION
From semconv:

> HTTP client spans have no http.route attribute since client-side instrumentation is not generally aware of the “route”, and therefore HTTP client span names SHOULD be [{method}](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#method-placeholder).
> 
> The {method} MUST be {http.request.method} if the method represents the original method known to the instrumentation. In other cases (when {http.request.method} is set to _OTHER), {method} MUST be HTTP.
> 
> Instrumentation MUST NOT default to using URI path as span name, but MAY provide hooks to allow custom logic to override the default span name.

This PR changes the HTTP client span name to the method name.
Related to https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/169