### PR TITLE
Support empty url path in HTTP client probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Change HTTP client span name to `{http.request.method}` ([#775](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/775))
-- Support empty url path in HTTP client probe ([#810](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/810))
+- Don't set empty URL path in HTTP client probe. ([#810](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/810))
+- Don't fail HTTP client probe attribute resolution on empty URL path. ([#810](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/810))
 
 
 ## [v0.12.0-alpha] - 2024-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Change HTTP client span name to `{http.request.method}` ([#775](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/775))
+- Support empty url path in HTTP client probe ([#810](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/810))
 
 
 ## [v0.12.0-alpha] - 2024-04-10

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf/probe.bpf.c
@@ -118,7 +118,6 @@ int uprobe_Transport_roundTrip(struct pt_regs *ctx) {
     bpf_probe_read(&url_ptr, sizeof(url_ptr), (void *)(req_ptr+url_ptr_pos));
     if (!get_go_string_from_user_ptr((void *)(url_ptr+path_ptr_pos), httpReq->path, sizeof(httpReq->path))) {
         bpf_printk("uprobe_Transport_roundTrip: Failed to get path from Request.URL");
-        return 0;
     }
 
     // get host from Request

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -223,8 +223,11 @@ func convertEvent(e *event) []*probe.SpanEvent {
 
 	attrs := []attribute.KeyValue{
 		semconv.HTTPRequestMethodKey.String(method),
-		semconv.URLPath(path),
 		semconv.HTTPResponseStatusCodeKey.Int(int(e.StatusCode)),
+	}
+
+	if path != "" {
+		attrs = append(attrs, semconv.HTTPURL(path))
 	}
 
 	// Server address and port

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -227,7 +227,7 @@ func convertEvent(e *event) []*probe.SpanEvent {
 	}
 
 	if path != "" {
-		attrs = append(attrs, semconv.HTTPURL(path))
+		attrs = append(attrs, semconv.URLPath(path))
 	}
 
 	// Server address and port

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -142,15 +142,15 @@
                   }
                 },
                 {
-                  "key": "url.path",
-                  "value": {
-                    "stringValue": "/query_db"
-                  }
-                },
-                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/query_db"
                   }
                 },
                 {

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -148,7 +148,7 @@
                   }
                 },
                 {
-                  "key": "http.url",
+                  "key": "url.path",
                   "value": {
                     "stringValue": "/query_db"
                   }

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -117,15 +117,15 @@
                   }
                 },
                 {
-                  "key": "url.path",
-                  "value": {
-                    "stringValue": "/hello-gin"
-                  }
-                },
-                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/hello-gin"
                   }
                 },
                 {

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -123,7 +123,7 @@
                   }
                 },
                 {
-                  "key": "http.url",
+                  "key": "url.path",
                   "value": {
                     "stringValue": "/hello-gin"
                   }

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -123,7 +123,7 @@
                   }
                 },
                 {
-                  "key": "http.url",
+                  "key": "url.path",
                   "value": {
                     "stringValue": "/hello"
                   }

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -117,15 +117,15 @@
                   }
                 },
                 {
-                  "key": "url.path",
-                  "value": {
-                    "stringValue": "/hello"
-                  }
-                },
-                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/hello"
                   }
                 },
                 {

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -123,7 +123,7 @@
                   }
                 },
                 {
-                  "key": "http.url",
+                  "key": "url.path",
                   "value": {
                     "stringValue": "/hello"
                   }

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -117,15 +117,15 @@
                   }
                 },
                 {
-                  "key": "url.path",
-                  "value": {
-                    "stringValue": "/hello"
-                  }
-                },
-                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/hello"
                   }
                 },
                 {


### PR DESCRIPTION
Currently, if we can't read the URL.path we drop the span. This PR changes this to support an empty path.