### PR TITLE
Test `arm64` builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ env:
   GO_VERSION: "~1.22.2"
 
 jobs:
-  generate-and-test:
+  generate-and-test-x86_64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -21,17 +21,36 @@ jobs:
           check-latest: true
           cache-dependency-path: "**/go.sum"
       - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y clang llvm libbpf-dev
+      - name: Archetecture
         run: |
-          sudo apt-get update && sudo apt-get install -y clang llvm libbpf-dev
-      - name: make generate
+          uname -p;
+          clang --version;
+      - run: make test
+      - run: make check-clean-work-tree
+  generate-and-test-arm64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache-dependency-path: "**/go.sum"
+      - name: Install build dependencies
         run: |
-          make generate
-      - name: verify output
+          brew update && brew install llvm
+          echo "PATH=/opt/homebrew/opt/llvm/bin:$PATH" >> $GITHUB_ENV;
+          echo "LDFLAGS=-L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" >> $GITHUB_ENV;
+          echo "CPPFLAGS=-I/opt/homebrew/opt/llvm/include" >> $GITHUB_ENV;
+      - name: Archetecture
         run: |
-          make check-clean-work-tree
-      - name: Run unit tests
-        run: |
-          make test
+          uname -p;
+          clang --version;
+      - run: make test
+      - run: make check-clean-work-tree
   docker-build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use the latest MacOS runners that use the new M1 chips to test the bpf build steps.