### PR TITLE
Flush on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Fix dirty shutdown caused by panic. ([#980](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/980))
+- Flush pending span exports on shutdown. ([#1028](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1028))
 
 ## [v0.14.0-alpha] - 2024-07-15
 

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -102,3 +102,16 @@ func NewController(logger logr.Logger, tracerProvider trace.TracerProvider, ver 
 		bootTime:       bt,
 	}, nil
 }
+
+// Shutdown shuts down the OpenTelemetry TracerProvider.
+//
+// Once shut down, calls to Trace will result in no-op spans (i.e. dropped).
+func (c *Controller) Shutdown(ctx context.Context) error {
+	if s, ok := c.tracerProvider.(interface {
+		Shutdown(context.Context) error
+	}); ok {
+		// Default TracerProvider implementation.
+		return s.Shutdown(ctx)
+	}
+	return nil
+}


### PR DESCRIPTION
When the `Manager` stops, flush the `Controller` and any held telemetry.

Unblocks #984 