### PR TITLE
Increase BSP timeout for a more consistent batch size in e2e tests

### DIFF
--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -38,6 +38,8 @@ spec:
           value: "tracecontext,baggage"
         - name: OTEL_GO_AUTO_INCLUDE_DB_STATEMENT
           value: "true"
+        - name: OTEL_BSP_SCHEDULE_DELAY
+          value: "60000"
         resources: {}
         securityContext:
           runAsUser: 0

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -137,67 +137,7 @@
               "spanId": "xxxxx",
               "status": {},
               "traceId": "xxxxx"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.23.0 linux/amd64"
-            }
-          },
-          {
-            "key": "process.runtime.name",
-            "value": {
-              "stringValue": "go"
-            }
-          },
-          {
-            "key": "process.runtime.version",
-            "value": {
-              "stringValue": "1.23.0"
-            }
-          },
-          {
-            "key": "service.name",
-            "value": {
-              "stringValue": "sample-app"
-            }
-          },
-          {
-            "key": "telemetry.distro.name",
-            "value": {
-              "stringValue": "opentelemetry-go-instrumentation"
-            }
-          },
-          {
-            "key": "telemetry.distro.version",
-            "value": {
-              "stringValue": "v0.14.0-alpha"
-            }
-          },
-          {
-            "key": "telemetry.sdk.language",
-            "value": {
-              "stringValue": "go"
-            }
-          }
-        ]
-      },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
-      "scopeSpans": [
-        {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
-          "scope": {
-            "name": "go.opentelemetry.io/auto/github.com/segmentio/kafka-go",
-            "version": "v0.14.0-alpha"
-          },
-          "spans": [
+            },
             {
               "attributes": [
                 {

--- a/internal/test/e2e/kafka-go/verify.bats
+++ b/internal/test/e2e/kafka-go/verify.bats
@@ -7,7 +7,7 @@ SCOPE="go.opentelemetry.io/auto/github.com/segmentio/kafka-go"
 @test "go-auto :: includes service.name in resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"service.name\").value.stringValue")
   result_separated=$(echo $result | sed 's/\n/,/g')
-  assert_equal "$result_separated" '"sample-app" "sample-app"'
+  assert_equal "$result_separated" '"sample-app"'
 }
 
 @test "kafka producer,consumer :: valid {messaging.system} for all spans" {


### PR DESCRIPTION
* Setting `OTEL_BSP_SCHEDULE_DELAY` to 1 minute (instead of the default 5 seconds) - this should make the batches being exported in the test apps more consistent - after #1028.
* As a result the `kafka-go` test is now exporting the spans in a single batch.