### PR TITLE
Remove private consts type redeclaration

### DIFF
--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -90,10 +90,10 @@ const (
 
 // Manifest returns the Probe's instrumentation Manifest.
 func (i *Base[BPFObj, BPFEvent]) Manifest() Manifest {
-	var structFieldIds []structfield.ID
+	var structFieldIDs []structfield.ID
 	for _, cnst := range i.Consts {
 		if sfc, ok := cnst.(StructFieldConst); ok {
-			structFieldIds = append(structFieldIds, sfc.Val)
+			structFieldIDs = append(structFieldIDs, sfc.Val)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (i *Base[BPFObj, BPFEvent]) Manifest() Manifest {
 		symbols = append(symbols, FunctionSymbol{Symbol: up.Sym, DependsOn: up.DependsOn})
 	}
 
-	return NewManifest(i.ID, structFieldIds, symbols)
+	return NewManifest(i.ID, structFieldIDs, symbols)
 }
 
 func (i *Base[BPFObj, BPFEvent]) Spec() (*ebpf.CollectionSpec, error) {


### PR DESCRIPTION
Looking through the Probe api this private wrapper for Consts seems to just provide these two helpers. They aren't very big so I think moving that logic to their main functions actually makes the code a little more readable by removing that layer of abstraction. Just a small change while we're looking toward renovating this api. Please correct me if I'm wrong