### PR TITLE
Example DB and HTTP custom Probe configs

### DIFF
--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -26,6 +26,7 @@ import (
 	httpServer "go.opentelemetry.io/auto/internal/pkg/instrumentation/bpf/net/http/server"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/bpffs"
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe"
+	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 	"go.opentelemetry.io/auto/internal/pkg/opentelemetry"
 	"go.opentelemetry.io/auto/internal/pkg/process"
 )
@@ -366,8 +367,16 @@ func availableProbes(l *slog.Logger, withTraceGlobal bool) []probe.Probe {
 		grpcClient.New(l),
 		grpcServer.New(l),
 		httpServer.New(l),
-		httpClient.New(l),
-		dbSql.New(l),
+		httpClient.New(l,
+			&httpClient.Config{
+				SupportsContextPropagation: utils.SupportsContextPropagation(),
+			},
+		),
+		dbSql.New(l,
+			&dbSql.Config{
+				IncludeQueryText: true, //example
+			},
+		),
 		kafkaProducer.New(l),
 		kafkaConsumer.New(l),
 		autosdk.New(l),

--- a/internal/pkg/instrumentation/probe/config.go
+++ b/internal/pkg/instrumentation/probe/config.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package probe provides instrumentation probe types and definitions.
+package probe
+
+type Config interface {
+	// Package returns the name of the package instrumented by this [Probe].
+	Package() string
+}


### PR DESCRIPTION
Showing probe-specific config based on a config interface (ref https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/1105) with db and http as examples

the common `probe.Config` interface lets us enforce methods that all Probes should support (in this example I picked package name)

then each Probe can define their own config settings within their own package.