### PR TITLE
Add span events to the SDK and SDK probe

### DIFF
--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/probe.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/probe.go
@@ -200,7 +200,7 @@ func events(e ptrace.SpanEventSlice) map[string][]trace.EventOption {
 	}
 	return out
 }
-  
+
 func (c *converter) links(links ptrace.SpanLinkSlice) []trace.Link {
 	n := links.Len()
 	if n == 0 {

--- a/internal/pkg/instrumentation/probe/event.go
+++ b/internal/pkg/instrumentation/probe/event.go
@@ -35,4 +35,5 @@ type SpanEvent struct {
 	TracerName        string
 	TracerVersion     string
 	TracerSchema      string
+	Events            map[string][]trace.EventOption
 }

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -78,7 +78,7 @@ func (c *Controller) Trace(event *probe.Event) {
 				trace.WithAttributes(se.Attributes...),
 				trace.WithSpanKind(kind),
 				trace.WithTimestamp(se.StartTime),
-    		trace.WithLinks(se.Links...),
+				trace.WithLinks(se.Links...),
 			)
 		for name, opts := range se.Events {
 			span.AddEvent(name, opts...)

--- a/internal/pkg/opentelemetry/controller.go
+++ b/internal/pkg/opentelemetry/controller.go
@@ -78,6 +78,9 @@ func (c *Controller) Trace(event *probe.Event) {
 				trace.WithAttributes(se.Attributes...),
 				trace.WithSpanKind(kind),
 				trace.WithTimestamp(se.StartTime))
+		for name, opts := range se.Events {
+			span.AddEvent(name, opts...)
+		}
 		span.SetStatus(se.Status.Code, se.Status.Description)
 		span.End(trace.WithTimestamp(se.EndTime))
 	}

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -64,7 +64,7 @@
               "startTimeUnixNano": "946684800000010000",
               "endTimeUnixNano": "946684800000110000",
               "status": {}
-             }
+            },
             {
               "traceId": "xxxxx",
               "spanId": "xxxxx",
@@ -135,7 +135,7 @@
                   }
                 }
               ],
-              "status": {},
+              "status": {}
             },
             {
               "traceId": "xxxxx",

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -63,6 +63,38 @@
               "kind": 1,
               "startTimeUnixNano": "946684800500000000",
               "endTimeUnixNano": "946684801000000000",
+              "events": [
+                {
+                  "timeUnixNano": "946684802000000000",
+                  "name": "exception",
+                  "attributes": [
+                    {
+                      "key": "impact",
+                      "value": {
+                        "intValue": "11"
+                      }
+                    },
+                    {
+                      "key": "exception.type",
+                      "value": {
+                        "stringValue": "*errors.errorString"
+                      }
+                    },
+                    {
+                      "key": "exception.message",
+                      "value": {
+                        "stringValue": "broken"
+                      }
+                    },
+                    {
+                      "key": "exception.stacktrace",
+                      "value": {
+                        "stringValue": "xxxxx"
+                      }
+                    }
+                  ]
+                }
+              ],
               "attributes": [
                 {
                   "key": "user",

--- a/internal/test/test_helpers/utilities.sh
+++ b/internal/test/test_helpers/utilities.sh
@@ -68,6 +68,13 @@ resource_attributes_received() {
 	spans_received | jq ".resource.attributes[]?"
 }
 
+# Returns an array of all span events emitted by a given library/scope and span.
+# $1 - library/scope name
+# $2 - span name
+span_events() {
+	spans_from_scope_named $1 | jq "select(.name == \"$2\").events[]"
+}
+
 # Returns an array of all spans emitted by a given library/scope
 	# $1 - library/scope name
 spans_from_scope_named() {

--- a/sdk/trace_test.go
+++ b/sdk/trace_test.go
@@ -5,6 +5,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -329,6 +330,35 @@ func TestSpanIsRecording(t *testing.T) {
 	builder.NotSampled = true
 	s = builder.Build()
 	assert.False(t, s.IsRecording(), "unsampled span should not be recorded")
+}
+
+func TestSpanRecordError(t *testing.T) {
+	s := spanBuilder{}.Build()
+
+	want := ptrace.NewSpanEventSlice()
+	s.RecordError(nil)
+	require.Equal(t, want, s.span.Events(), "nil error recorded")
+
+	ts := time.Now()
+	err := errors.New("test")
+	s.RecordError(
+		err,
+		trace.WithTimestamp(ts),
+		trace.WithAttributes(attribute.Bool("testing", true)),
+	)
+	e := want.AppendEmpty()
+	e.SetName(semconv.ExceptionEventName)
+	e.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	e.Attributes().PutBool("testing", true)
+	e.Attributes().PutStr(string(semconv.ExceptionTypeKey), "*errors.errorString")
+	e.Attributes().PutStr(string(semconv.ExceptionMessageKey), err.Error())
+	assert.Equal(t, want, s.span.Events(), "nil error recorded")
+
+	s.RecordError(err, trace.WithStackTrace(true))
+	require.Equal(t, 2, s.span.Events().Len(), "missing event")
+	e = s.span.Events().At(1)
+	_, ok := e.Attributes().Get(string(semconv.ExceptionStacktraceKey))
+	assert.True(t, ok, "missing stacktrace attribute")
 }
 
 func TestSpanSpanContext(t *testing.T) {


### PR DESCRIPTION
Blocked by #1133

- Add events to span in SDK
- Process events in probe and auto-instrumentation agent
- Test the event addition

Part of #954 