### PR TITLE
Release v0.16.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Support `go.opentelemetry.io/otel@v1.31.0`. ([#1178](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1178))
 - Support `google.golang.org/grpc` `1.69.0-dev`. ([#1203](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1203))
 - Implement traceID ratio and parent-based samplers. ([#1150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1150))
+- The `go.opentelemetry.io/auto/sdk` module.
+  This module is used directly when you want to explicilty use auto-instrumentation to process OTel API telemetry.
+  It is also provided so the default OTel global API will use this when auto-instrumentation is loaded (WIP). ([#1210](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1210))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.16.0-alpha] - 2024-10-22
+
 ### Added
 
 - Support `golang.org/x/net` `v0.30.0`. ([#1149](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1149))
@@ -446,7 +448,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.15.0-alpha...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.16.0-alpha...HEAD
+[v0.16.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.16.0-alpha
 [v0.15.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.15.0-alpha
 [v0.14.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.14.0-alpha
 [v0.13.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.13.0-alpha

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/auto/sdk v0.16.0-alpha
+	go.opentelemetry.io/auto/sdk v0.1.0-alpha
 	go.opentelemetry.io/contrib/exporters/autoexport v0.56.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/auto/sdk v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/auto/sdk v0.16.0-alpha
 	go.opentelemetry.io/contrib/exporters/autoexport v0.56.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/database/sql",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {
@@ -79,7 +79,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/github.com/segmentio/kafka-go",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.15.0-alpha"
+            "version": "v0.16.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.15.0-alpha"
+              "stringValue": "v0.16.0-alpha"
             }
           },
           {

--- a/sdk/telemetry/test/go.mod
+++ b/sdk/telemetry/test/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/auto/sdk v0.16.0-alpha
+	go.opentelemetry.io/auto/sdk v0.1.0-alpha
 	go.opentelemetry.io/collector/pdata v1.17.0
 )
 

--- a/sdk/telemetry/test/go.mod
+++ b/sdk/telemetry/test/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/auto/sdk v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/auto/sdk v0.16.0-alpha
 	go.opentelemetry.io/collector/pdata v1.17.0
 )
 

--- a/version.go
+++ b/version.go
@@ -5,5 +5,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.15.0-alpha"
+	return "v0.16.0-alpha"
 }

--- a/version_test.go
+++ b/version_test.go
@@ -38,6 +38,6 @@ func TestVersionMatchesYaml(t *testing.T) {
 	}
 
 	// incredibad, but it's where the intended version is declared at the moment
-	expectedVersion := versionInfo["module-sets"].(map[string]interface{})["alpha"].(map[string]interface{})["version"]
+	expectedVersion := versionInfo["module-sets"].(map[string]interface{})["auto"].(map[string]interface{})["version"]
 	assert.Equal(t, expectedVersion, Version(), "Build version should match versions.yaml.")
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,6 @@ module-sets:
     modules:
       - go.opentelemetry.io/auto
       - go.opentelemetry.io/auto/sdk
-      - go.opentelemetry.io/auto/sdk/telemetry/test
 excluded-modules:
   - github.com/hashicorp/go-version
   - go.opentelemetry.io/auto/examples
@@ -23,3 +22,4 @@ excluded-modules:
   - go.opentelemetry.io/auto/internal/test/e2e/nethttp
   - go.opentelemetry.io/auto/internal/test/e2e/otelglobal
   - go.opentelemetry.io/auto/internal/tools
+  - go.opentelemetry.io/auto/sdk/telemetry/test

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   alpha:
-    version: v0.15.0-alpha
+    version: v0.16.0-alpha
     modules:
       - go.opentelemetry.io/auto
 excluded-modules:

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 module-sets:
-  alpha:
+  auto:
     version: v0.16.0-alpha
     modules:
       - go.opentelemetry.io/auto
+  sdk:
+    version: v0.1.0-alpha
+    modules:
       - go.opentelemetry.io/auto/sdk
 excluded-modules:
   - github.com/hashicorp/go-version

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,8 @@ module-sets:
     version: v0.16.0-alpha
     modules:
       - go.opentelemetry.io/auto
+      - go.opentelemetry.io/auto/sdk
+      - go.opentelemetry.io/auto/sdk/telemetry/test
 excluded-modules:
   - github.com/hashicorp/go-version
   - go.opentelemetry.io/auto/examples
@@ -21,5 +23,3 @@ excluded-modules:
   - go.opentelemetry.io/auto/internal/test/e2e/nethttp
   - go.opentelemetry.io/auto/internal/test/e2e/otelglobal
   - go.opentelemetry.io/auto/internal/tools
-  - go.opentelemetry.io/auto/sdk
-  - go.opentelemetry.io/auto/sdk/telemetry/test


### PR DESCRIPTION
### Added

- Support `golang.org/x/net` `v0.30.0`. ([#1149](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1149))
- Support `google.golang.org/grpc` `1.65.1`. ([#1174](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1174))
- Support `go.opentelemetry.io/otel@v1.31.0`. ([#1178](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1178))
- Support `google.golang.org/grpc` `1.69.0-dev`. ([#1203](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1203))
- Implement traceID ratio and parent-based samplers. ([#1150](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1150))
- The `go.opentelemetry.io/auto/sdk` module. This module is used directly when you want to explicilty use auto-instrumentation to process OTel API telemetry. It is also provided so the default OTel global API will use this when auto-instrumentation is loaded (WIP). ([#1210](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1210))

### Fixed

- The `"golang.org/x/net/http2".FrameHeader.StreamID` offset for version `0.8.0` is corrected. ([#1208](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1208))
- The `"golang.org/x/net/http2".MetaHeadersFrame.Fields` offset for version `0.8.0` is corrected. ([#1208](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1208))
