### PR TITLE
Clean-up Makefile test target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           uname -p;
           clang --version;
       - run: make test
-      - run: sudo make test_ebpf
+      - run: sudo make test-ebpf
       - run: make check-clean-work-tree
   generate-and-test-arm64:
     runs-on: macos-latest


### PR DESCRIPTION
- Correct `test_ebpf` to `test-epbf` to match existing make target
- Remove `go-mod-tidy` from `precommit` as it is already a dependency of the other targets run
- Add `test` target to `precommit` so it is run by default
- Do not include verbose output in default `test` target
- Unify `test_ebpf` target into `test` target as they are functionally identical
- Add a `test-verbose` target to run tests with verbose output