### PR TITLE
Fix `Manager.Run` stop deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Fixed
+
+- Sporadic shutdown deadlock. ([#1220](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1220))
+
 ## [v0.16.0-alpha] - 2024-10-22
 
 ### Added


### PR DESCRIPTION
Fix #1218

Close probes in a different goroutine than the one draining their event channel.