### PR TITLE
Embed noop into sdk instead of embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Changed
+
+- The SDK provided in `go.opentelemtry.io/auto/sdk` now defaults to NoOp behavior for unimplemented methods of the OpenTelemetry API.
+  This is changed from causing a compilation error for unimplemented methods. ([#1230](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1230))
+
 ### Fixed
 
 - Sporadic shutdown deadlock. ([#1220](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1220))

--- a/sdk/trace.go
+++ b/sdk/trace.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/auto/sdk/telemetry"
 )
@@ -31,7 +31,7 @@ func GetTracerProvider() trace.TracerProvider { return tracerProviderInstance }
 
 var tracerProviderInstance = tracerProvider{}
 
-type tracerProvider struct{ embedded.TracerProvider }
+type tracerProvider struct{ noop.TracerProvider }
 
 var _ trace.TracerProvider = tracerProvider{}
 
@@ -45,7 +45,7 @@ func (p tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tr
 }
 
 type tracer struct {
-	embedded.Tracer
+	noop.Tracer
 
 	name, schemaURL, version string
 }
@@ -140,7 +140,7 @@ func spanKind(kind trace.SpanKind) telemetry.SpanKind {
 }
 
 type span struct {
-	embedded.Span
+	noop.Span
 
 	sampled     bool
 	spanContext trace.SpanContext


### PR DESCRIPTION
Default to NoOp behavior when the `sdk` pkg does not implement a method of the Go OTel API instead of causing a compilation error.

Resolve #1228