### PR TITLE
Use CGO_ENBABLED=0 for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ golangci-lint/%: | $(GOLANGCI_LINT)
 
 .PHONY: build
 build: generate
-	$(GOCMD) build -o otel-go-instrumentation ./cli/...
+	CGO_ENABLED=0 $(GOCMD) build -o otel-go-instrumentation ./cli/...
 
 .PHONY: docker-build
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BPF_INCLUDE += -I${REPODIR}/internal/include
 
 # Go default variables
 GOCMD?= go
+CGO_ENABLED?=0
 
 .DEFAULT_GOAL := precommit
 
@@ -93,7 +94,7 @@ golangci-lint/%: | $(GOLANGCI_LINT)
 
 .PHONY: build
 build: generate
-	CGO_ENABLED=0 $(GOCMD) build -o otel-go-instrumentation ./cli/...
+	CGO_ENABLED=$(CGO_ENABLED) $(GOCMD) build -o otel-go-instrumentation ./cli/...
 
 .PHONY: docker-build
 docker-build:


### PR DESCRIPTION
We used to have a dependency that required CGO_ENABLED - this was removed in https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/624.
According to https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1215, it seems we are building with CGO_ENABLED (even though we don't have to).