### PR TITLE
Fix make generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,16 @@ test/%/go.mod:
 
 PROBE_ROOT = internal/pkg/instrumentation/bpf/
 PROBE_GEN_GO := $(shell find $(PROBE_ROOT) -type f -name 'bpf_*_bpfe[lb].go')
+PROBE_GEN_OBJ := $(PROBE_GEN_GO:.go=.o)
+PROBE_GEN_ALL := $(PROBE_GEN_GO) $(PROBE_GEN_OBJ)
 
 # Include all depinfo files to ensure we only re-generate when needed.
 -include $(shell find $(PROBE_ROOT) -type f -name 'bpf_*_bpfel.go.d')
 
 .PHONY: generate generate/all
-generate: $(PROBE_GEN_GO)
+generate: $(PROBE_GEN_ALL)
 
-$(PROBE_GEN_GO):
+$(PROBE_GEN_ALL):
 	$(GOCMD) generate ./$(dir $@)...
 
 generate/all:

--- a/Makefile
+++ b/Makefile
@@ -64,16 +64,14 @@ test/%/go.mod:
 
 PROBE_ROOT = internal/pkg/instrumentation/bpf/
 PROBE_GEN_GO := $(shell find $(PROBE_ROOT) -type f -name 'bpf_*_bpfe[lb].go')
-PROBE_GEN_OBJ := $(PROBE_GEN_GO:.go=.o)
 
 # Include all depinfo files to ensure we only re-generate when needed.
 -include $(shell find $(PROBE_ROOT) -type f -name 'bpf_*_bpfel.go.d')
 
 .PHONY: generate generate/all
 generate: $(PROBE_GEN_GO)
-$(PROBE_GEN_GO): %.go: %.o
 
-$(PROBE_GEN_OBJ):
+$(PROBE_GEN_GO):
 	$(GOCMD) generate ./$(dir $@)...
 
 generate/all:


### PR DESCRIPTION
The `PROBE_GEN_OBJ` targets are relevant when no object files are present (this is the case in CI, or in a fresh clone). However, when a `.c` files is being edited these targets won't cause re-generation (since the object files didn't change).
The `PROBE_GEN_GO` targets are relevant when the source code is being edited - these targets are included in the `.d` files with dependencies on the relevant source code files.