### PR TITLE
Don't include db.query if it is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't include `db.query.text` attribute in `database/sql` if the query string is empty or not collected. ([#1246](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1246))
+
 ## [v0.17.0-alpha] - 2024-11-05
 
 ### Changed

--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -93,7 +93,9 @@ func processFn(e *event) ptrace.SpanSlice {
 	}
 
 	query := unix.ByteSliceToString(e.Query[:])
-	span.Attributes().PutStr(string(semconv.DBQueryTextKey), query)
+	if query != "" {
+		span.Attributes().PutStr(string(semconv.DBQueryTextKey), query)
+	}
 
 	return spans
 }


### PR DESCRIPTION
If the `OTEL_GO_AUTO_INCLUDE_DB_STATEMENT` environment variable is not set, we won't collect the SQL query, hence in that case there is no point in adding an empty attribute.

Related to https://github.com/odigos-io/odigos/issues/1695