### PR TITLE
Support SELECT/INSERT/UPDATE/DELETE db operation + span names

### DIFF
--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -38,6 +38,8 @@ spec:
           value: "tracecontext,baggage"
         - name: OTEL_GO_AUTO_INCLUDE_DB_STATEMENT
           value: "true"
+        - name: OTEL_GO_AUTO_INCLUDE_DB_OPERATION
+          value: "true"
         - name: OTEL_BSP_SCHEDULE_DELAY
           value: "60000"
         resources: {}

--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -38,7 +38,7 @@ spec:
           value: "tracecontext,baggage"
         - name: OTEL_GO_AUTO_INCLUDE_DB_STATEMENT
           value: "true"
-        - name: OTEL_GO_AUTO_INCLUDE_DB_OPERATION
+        - name: OTEL_GO_AUTO_PARSE_DB_STATEMENT
           value: "true"
         - name: OTEL_BSP_SCHEDULE_DELAY
           value: "60000"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Support `google.golang.org/grpc` `1.68.0`. ([#1251](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1251))
 - Support `golang.org/x/net` `0.31.0`. ([#1254](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1254))
 - Support `go.opentelemetry.io/otel@v1.32.0`. ([#1302](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1302))
+- Support `SELECT`, `INSERT`, `UPDATE`, and `DELETE` for database span names and `db.operation.name` attribute. ([#1253](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1253))
 
 ### Fixed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ Alternatively, you can add support for additional or different configurations by
 | Environment variable                | Description                                            | Default value |
 |-------------------------------------|--------------------------------------------------------|---------------|
 | `OTEL_GO_AUTO_INCLUDE_DB_STATEMENT` | Sets whether to include SQL queries in the trace data. |               |
+| `OTEL_GO_AUTO_INCLUDE_DB_OPERATION` | Sets whether to include SQL operation in the trace data. |               |
 
 ## Traces exporter
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ Alternatively, you can add support for additional or different configurations by
 | Environment variable                | Description                                            | Default value |
 |-------------------------------------|--------------------------------------------------------|---------------|
 | `OTEL_GO_AUTO_INCLUDE_DB_STATEMENT` | Sets whether to include SQL queries in the trace data. |               |
-| `OTEL_GO_AUTO_INCLUDE_DB_OPERATION` | Sets whether to include SQL operation in the trace data. |               |
+| `OTEL_GO_AUTO_PARSE_DB_STATEMENT` | Sets whether to parse the SQL statement for trace data, setting `db.operation.name`. Only valid if `OTEL_GO_AUTO_INCLUDE_DB_STATEMENT` is also set. |               |
 
 ## Traces exporter
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.21.0
+	github.com/stretchr/testify v1.9.0
+	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	go.opentelemetry.io/contrib/exporters/autoexport v0.57.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.21.0
-	github.com/stretchr/testify v1.9.0
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
+	go.opentelemetry.io/collector/pdata v1.21.0
 	go.opentelemetry.io/contrib/exporters/autoexport v0.57.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
+github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/collector/pdata v1.21.0 h1:PG+UbiFMJ35X/WcAR7Rf/PWmWtRdW0aHlOidsR6c5MA=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -4,6 +4,7 @@
 package sql
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -70,6 +71,8 @@ func BenchmarkProcessFn(b *testing.B) {
 }
 
 func TestProbeConvertEvent(t *testing.T) {
+	err := os.Setenv(IncludeDBOperationEnvVar, "true")
+	assert.NoError(t, err)
 	start := time.Unix(0, time.Now().UnixNano()) // No wall clock.
 	end := start.Add(1 * time.Second)
 

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -54,6 +54,7 @@ func BenchmarkProcessFn(b *testing.B) {
 		b.Run(t.name, func(b *testing.B) {
 			var byteQuery [256]byte
 			copy(byteQuery[:], []byte(t.query))
+			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = processFn(&event{
@@ -70,7 +71,7 @@ func BenchmarkProcessFn(b *testing.B) {
 }
 
 func TestProbeConvertEvent(t *testing.T) {
-	t.Setenv(IncludeDBOperationEnvVar, "true")
+	t.Setenv(ParseDBStatementEnvVar, "true")
 	start := time.Unix(0, time.Now().UnixNano()) // No wall clock.
 	end := start.Add(1 * time.Second)
 

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -4,7 +4,6 @@
 package sql
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -71,8 +70,7 @@ func BenchmarkProcessFn(b *testing.B) {
 }
 
 func TestProbeConvertEvent(t *testing.T) {
-	err := os.Setenv(IncludeDBOperationEnvVar, "true")
-	assert.NoError(t, err)
+	t.Setenv(IncludeDBOperationEnvVar, "true")
 	start := time.Unix(0, time.Now().UnixNano()) // No wall clock.
 	end := start.Add(1 * time.Second)
 
@@ -95,14 +93,14 @@ func TestProbeConvertEvent(t *testing.T) {
 	want := func() ptrace.SpanSlice {
 		spans := ptrace.NewSpanSlice()
 		span := spans.AppendEmpty()
-		span.SetName("SELECT")
+		span.SetName("SELECT foo")
 		span.SetKind(ptrace.SpanKindClient)
 		span.SetStartTimestamp(utils.BootOffsetToTimestamp(startOffset))
 		span.SetEndTimestamp(utils.BootOffsetToTimestamp(endOffset))
 		span.SetTraceID(pcommon.TraceID(traceID))
 		span.SetSpanID(pcommon.SpanID(spanID))
 		span.SetFlags(uint32(trace.FlagsSampled))
-		utils.Attributes(span.Attributes(), semconv.DBQueryText("SELECT * FROM foo"), semconv.DBOperationName("SELECT"))
+		utils.Attributes(span.Attributes(), semconv.DBQueryText("SELECT * FROM foo"), semconv.DBOperationName("SELECT"), semconv.DBCollectionName("foo"))
 		return spans
 	}()
 	assert.Equal(t, want, got)

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -41,14 +41,14 @@ func TestProbeConvertEvent(t *testing.T) {
 	want := func() ptrace.SpanSlice {
 		spans := ptrace.NewSpanSlice()
 		span := spans.AppendEmpty()
-		span.SetName("DB")
+		span.SetName("SELECT")
 		span.SetKind(ptrace.SpanKindClient)
 		span.SetStartTimestamp(utils.BootOffsetToTimestamp(startOffset))
 		span.SetEndTimestamp(utils.BootOffsetToTimestamp(endOffset))
 		span.SetTraceID(pcommon.TraceID(traceID))
 		span.SetSpanID(pcommon.SpanID(spanID))
 		span.SetFlags(uint32(trace.FlagsSampled))
-		utils.Attributes(span.Attributes(), semconv.DBQueryText("SELECT * FROM foo"))
+		utils.Attributes(span.Attributes(), semconv.DBQueryText("SELECT * FROM foo"), semconv.DBOperationName("SELECT"))
 		return spans
 	}()
 	assert.Equal(t, want, got)

--- a/internal/test/e2e/databasesql/main.go
+++ b/internal/test/e2e/databasesql/main.go
@@ -100,6 +100,118 @@ func (s *Server) queryDb(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (s *Server) insert(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	rows, err := conn.QueryContext(req.Context(), "INSERT INTO contacts (first_name) VALUES ('Mike')")
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("queryDb called")
+	for rows.Next() {
+		var id int
+		var firstName string
+		var lastName string
+		var email string
+		var phone string
+		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
+	}
+}
+
+func (s *Server) update(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	rows, err := conn.QueryContext(req.Context(), "UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'")
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("queryDb called")
+	for rows.Next() {
+		var id int
+		var firstName string
+		var lastName string
+		var email string
+		var phone string
+		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
+	}
+}
+
+func (s *Server) delete(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	rows, err := conn.QueryContext(req.Context(), "DELETE FROM contacts WHERE first_name = 'Mike'")
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("queryDb called")
+	for rows.Next() {
+		var id int
+		var firstName string
+		var lastName string
+		var email string
+		var phone string
+		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
+	}
+}
+
+func (s *Server) drop(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	rows, err := conn.QueryContext(req.Context(), "DROP TABLE contacts")
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("queryDb called")
+	for rows.Next() {
+		var id int
+		var firstName string
+		var lastName string
+		var email string
+		var phone string
+		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
+	}
+}
+
 var logger *zap.Logger
 
 func main() {
@@ -115,6 +227,10 @@ func main() {
 	s := NewServer()
 
 	http.HandleFunc("/query_db", s.queryDb)
+	http.HandleFunc("/insert", s.insert)
+	http.HandleFunc("/update", s.update)
+	http.HandleFunc("/delete", s.delete)
+	http.HandleFunc("/drop", s.drop)
 	go func() {
 		_ = http.ListenAndServe(":8080", nil)
 	}()
@@ -127,6 +243,54 @@ func main() {
 		logger.Error("Error performing GET", zap.Error(err))
 	}
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error reading http body", zap.Error(err))
+	}
+
+	logger.Info("Body:\n", zap.String("body", string(body[:])))
+	_ = resp.Body.Close()
+
+	resp, err = http.Get("http://localhost:8080/insert")
+	if err != nil {
+		logger.Error("Error performing GET", zap.Error(err))
+	}
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error reading http body", zap.Error(err))
+	}
+
+	logger.Info("Body:\n", zap.String("body", string(body[:])))
+	_ = resp.Body.Close()
+
+	resp, err = http.Get("http://localhost:8080/update")
+	if err != nil {
+		logger.Error("Error performing GET", zap.Error(err))
+	}
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error reading http body", zap.Error(err))
+	}
+
+	logger.Info("Body:\n", zap.String("body", string(body[:])))
+	_ = resp.Body.Close()
+
+	resp, err = http.Get("http://localhost:8080/delete")
+	if err != nil {
+		logger.Error("Error performing GET", zap.Error(err))
+	}
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("Error reading http body", zap.Error(err))
+	}
+
+	logger.Info("Body:\n", zap.String("body", string(body[:])))
+	_ = resp.Body.Close()
+
+	resp, err = http.Get("http://localhost:8080/drop")
+	if err != nil {
+		logger.Error("Error performing GET", zap.Error(err))
+	}
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error("Error reading http body", zap.Error(err))
 	}

--- a/internal/test/e2e/databasesql/main.go
+++ b/internal/test/e2e/databasesql/main.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	sqlQuery = "SELECT * FROM contacts"
-	dbName   = "test.db"
+	dbName = "test.db"
 
 	tableDefinition = `CREATE TABLE contacts (
 							contact_id INTEGER PRIMARY KEY,
@@ -72,132 +71,20 @@ func NewServer() *Server {
 	}
 }
 
-func (s *Server) queryDb(w http.ResponseWriter, req *http.Request) {
+func (s *Server) query(w http.ResponseWriter, req *http.Request, query string) {
 	ctx := req.Context()
-
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		panic(err)
 	}
 
-	rows, err := conn.QueryContext(req.Context(), sqlQuery)
+	rows, err := conn.QueryContext(req.Context(), query)
 	if err != nil {
-		panic(err)
+		logger.Error(err.Error())
+		return
 	}
 
-	logger.Info("queryDb called")
-	for rows.Next() {
-		var id int
-		var firstName string
-		var lastName string
-		var email string
-		var phone string
-		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
-	}
-}
-
-func (s *Server) insert(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	rows, err := conn.QueryContext(req.Context(), "INSERT INTO contacts (first_name) VALUES ('Mike')")
-	if err != nil {
-		panic(err)
-	}
-
-	logger.Info("insert called")
-	for rows.Next() {
-		var id int
-		var firstName string
-		var lastName string
-		var email string
-		var phone string
-		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
-	}
-}
-
-func (s *Server) update(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	rows, err := conn.QueryContext(req.Context(), "UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'")
-	if err != nil {
-		panic(err)
-	}
-
-	logger.Info("update called")
-	for rows.Next() {
-		var id int
-		var firstName string
-		var lastName string
-		var email string
-		var phone string
-		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
-	}
-}
-
-func (s *Server) delete(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	rows, err := conn.QueryContext(req.Context(), "DELETE FROM contacts WHERE first_name = 'Mike'")
-	if err != nil {
-		panic(err)
-	}
-
-	logger.Info("delete called")
-	for rows.Next() {
-		var id int
-		var firstName string
-		var lastName string
-		var email string
-		var phone string
-		err := rows.Scan(&id, &firstName, &lastName, &email, &phone)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Fprintf(w, "ID: %d, firstName: %s, lastName: %s, email: %s, phone: %s\n", id, firstName, lastName, email, phone)
-	}
-}
-
-func (s *Server) drop(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	rows, err := conn.QueryContext(req.Context(), "DROP TABLE contacts")
-	if err != nil {
-		panic(err)
-	}
-
-	logger.Info("drop called")
+	logger.Info("queryDB called", zap.String("query", query))
 	for rows.Next() {
 		var id int
 		var firstName string
@@ -214,6 +101,30 @@ func (s *Server) drop(w http.ResponseWriter, req *http.Request) {
 
 var logger *zap.Logger
 
+func (s *Server) selectDb(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "SELECT * FROM contacts")
+}
+
+func (s *Server) insert(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "INSERT INTO contacts (first_name) VALUES ('Mike')")
+}
+
+func (s *Server) update(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'")
+}
+
+func (s *Server) delete(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "DELETE FROM contacts WHERE first_name = 'Mike'")
+}
+
+func (s *Server) drop(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "DROP TABLE contacts")
+}
+
+func (s *Server) invalid(w http.ResponseWriter, req *http.Request) {
+	s.query(w, req, "syntax error")
+}
+
 func main() {
 	var err error
 	logger, err = zap.NewDevelopment()
@@ -226,77 +137,44 @@ func main() {
 
 	s := NewServer()
 
-	http.HandleFunc("/query_db", s.queryDb)
+	http.HandleFunc("/query_db", s.selectDb)
 	http.HandleFunc("/insert", s.insert)
 	http.HandleFunc("/update", s.update)
 	http.HandleFunc("/delete", s.delete)
 	http.HandleFunc("/drop", s.drop)
+	http.HandleFunc("/invalid", s.invalid)
 	go func() {
 		_ = http.ListenAndServe(":8080", nil)
 	}()
 
+	tests := []struct {
+		url string
+	}{
+		{url: "http://localhost:8080/query_db"},
+		{url: "http://localhost:8080/insert"},
+		{url: "http://localhost:8080/update"},
+		{url: "http://localhost:8080/delete"},
+		{url: "http://localhost:8080/drop"},
+		{url: "http://localhost:8080/invalid"},
+	}
+
 	// give time for auto-instrumentation to start up
 	time.Sleep(5 * time.Second)
 
-	resp, err := http.Get("http://localhost:8080/query_db")
-	if err != nil {
-		logger.Error("Error performing GET", zap.Error(err))
+	for _, t := range tests {
+		resp, err := http.Get(t.url)
+		if err != nil {
+			logger.Error("Error performing GET", zap.Error(err))
+		}
+		if resp != nil {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.Error("Error reading http body", zap.Error(err))
+			}
+			logger.Info("Body:\n", zap.String("body", string(body[:])))
+			_ = resp.Body.Close()
+		}
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Error reading http body", zap.Error(err))
-	}
-
-	logger.Info("Body:\n", zap.String("body", string(body[:])))
-	_ = resp.Body.Close()
-
-	resp, err = http.Get("http://localhost:8080/insert")
-	if err != nil {
-		logger.Error("Error performing GET", zap.Error(err))
-	}
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Error reading http body", zap.Error(err))
-	}
-
-	logger.Info("Body:\n", zap.String("body", string(body[:])))
-	_ = resp.Body.Close()
-
-	resp, err = http.Get("http://localhost:8080/update")
-	if err != nil {
-		logger.Error("Error performing GET", zap.Error(err))
-	}
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Error reading http body", zap.Error(err))
-	}
-
-	logger.Info("Body:\n", zap.String("body", string(body[:])))
-	_ = resp.Body.Close()
-
-	resp, err = http.Get("http://localhost:8080/delete")
-	if err != nil {
-		logger.Error("Error performing GET", zap.Error(err))
-	}
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Error reading http body", zap.Error(err))
-	}
-
-	logger.Info("Body:\n", zap.String("body", string(body[:])))
-	_ = resp.Body.Close()
-
-	resp, err = http.Get("http://localhost:8080/drop")
-	if err != nil {
-		logger.Error("Error performing GET", zap.Error(err))
-	}
-	body, err = io.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("Error reading http body", zap.Error(err))
-	}
-
-	logger.Info("Body:\n", zap.String("body", string(body[:])))
-	_ = resp.Body.Close()
 
 	// give time for auto-instrumentation to report signal
 	time.Sleep(5 * time.Second)

--- a/internal/test/e2e/databasesql/main.go
+++ b/internal/test/e2e/databasesql/main.go
@@ -113,7 +113,7 @@ func (s *Server) insert(w http.ResponseWriter, req *http.Request) {
 		panic(err)
 	}
 
-	logger.Info("queryDb called")
+	logger.Info("insert called")
 	for rows.Next() {
 		var id int
 		var firstName string
@@ -141,7 +141,7 @@ func (s *Server) update(w http.ResponseWriter, req *http.Request) {
 		panic(err)
 	}
 
-	logger.Info("queryDb called")
+	logger.Info("update called")
 	for rows.Next() {
 		var id int
 		var firstName string
@@ -169,7 +169,7 @@ func (s *Server) delete(w http.ResponseWriter, req *http.Request) {
 		panic(err)
 	}
 
-	logger.Info("queryDb called")
+	logger.Info("delete called")
 	for rows.Next() {
 		var id int
 		var firstName string
@@ -197,7 +197,7 @@ func (s *Server) drop(w http.ResponseWriter, req *http.Request) {
 		panic(err)
 	}
 
-	logger.Info("queryDb called")
+	logger.Info("drop called")
 	for rows.Next() {
 		var id int
 		var firstName string

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -63,6 +63,98 @@
                   "value": {
                     "stringValue": "SELECT * FROM contacts"
                   }
+                },
+                {
+                  "key": "db.operation.name",
+                  "value": {
+                    "stringValue": "SELECT"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "SELECT",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "db.query.text",
+                  "value": {
+                    "stringValue": "INSERT INTO contacts (first_name) VALUES ('Mike')"
+                  }
+                },
+                {
+                  "key": "db.operation.name",
+                  "value": {
+                    "stringValue": "INSERT"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "INSERT",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "db.query.text",
+                  "value": {
+                    "stringValue": "UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'"
+                  }
+                },
+                {
+                  "key": "db.operation.name",
+                  "value": {
+                    "stringValue": "UPDATE"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "UPDATE",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "db.query.text",
+                  "value": {
+                    "stringValue": "DELETE FROM contacts WHERE first_name = 'Mike'"
+                  }
+                },
+                {
+                  "key": "db.operation.name",
+                  "value": {
+                    "stringValue": "DELETE"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "DELETE",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "db.query.text",
+                  "value": {
+                    "stringValue": "DROP TABLE contacts"
+                  }
                 }
               ],
               "flags": 256,
@@ -156,6 +248,266 @@
                   }
                 },
                 {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/insert"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "::1"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "xxxxx"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/insert"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 2,
+              "name": "GET /insert",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/update"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "::1"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "xxxxx"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/update"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 2,
+              "name": "GET /update",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/delete"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "::1"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "xxxxx"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/delete"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 2,
+              "name": "GET /delete",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/drop"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "::1"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "xxxxx"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/drop"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 2,
+              "name": "GET /drop",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
@@ -171,6 +523,218 @@
                   "key": "url.full",
                   "value": {
                     "stringValue": "http://localhost:8080/query_db"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "GET",
+              "parentSpanId": "",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/insert"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:8080/insert"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "GET",
+              "parentSpanId": "",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/update"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:8080/update"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "GET",
+              "parentSpanId": "",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/delete"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:8080/delete"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "GET",
+              "parentSpanId": "",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/drop"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:8080/drop"
                   }
                 },
                 {

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -69,11 +69,17 @@
                   "value": {
                     "stringValue": "SELECT"
                   }
+                },
+                {
+                  "key": "db.collection.name",
+                  "value": {
+                    "stringValue": "contacts"
+                  }
                 }
               ],
               "flags": 256,
               "kind": 3,
-              "name": "SELECT",
+              "name": "SELECT contacts",
               "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},
@@ -92,11 +98,17 @@
                   "value": {
                     "stringValue": "INSERT"
                   }
+                },
+                {
+                  "key": "db.collection.name",
+                  "value": {
+                    "stringValue": "contacts"
+                  }
                 }
               ],
               "flags": 256,
               "kind": 3,
-              "name": "INSERT",
+              "name": "INSERT contacts",
               "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},
@@ -115,11 +127,17 @@
                   "value": {
                     "stringValue": "UPDATE"
                   }
+                },
+                {
+                  "key": "db.collection.name",
+                  "value": {
+                    "stringValue": "contacts"
+                  }
                 }
               ],
               "flags": 256,
               "kind": 3,
-              "name": "UPDATE",
+              "name": "UPDATE contacts",
               "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},
@@ -138,11 +156,17 @@
                   "value": {
                     "stringValue": "DELETE"
                   }
+                },
+                {
+                  "key": "db.collection.name",
+                  "value": {
+                    "stringValue": "contacts"
+                  }
                 }
               ],
               "flags": 256,
               "kind": 3,
-              "name": "DELETE",
+              "name": "DELETE contacts",
               "parentSpanId": "xxxxx",
               "spanId": "xxxxx",
               "status": {},
@@ -154,6 +178,23 @@
                   "key": "db.query.text",
                   "value": {
                     "stringValue": "DROP TABLE contacts"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "DB",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "db.query.text",
+                  "value": {
+                    "stringValue": "syntax error"
                   }
                 }
               ],
@@ -508,6 +549,71 @@
                   }
                 },
                 {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/invalid"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "network.peer.address",
+                  "value": {
+                    "stringValue": "::1"
+                  }
+                },
+                {
+                  "key": "network.peer.port",
+                  "value": {
+                    "intValue": "xxxxx"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/invalid"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 2,
+              "name": "GET /invalid",
+              "parentSpanId": "xxxxx",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
                   "key": "http.response.status_code",
                   "value": {
                     "intValue": "200"
@@ -735,6 +841,59 @@
                   "key": "url.full",
                   "value": {
                     "stringValue": "http://localhost:8080/drop"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "8080"
+                  }
+                },
+                {
+                  "key": "network.protocol.version",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                }
+              ],
+              "flags": 256,
+              "kind": 3,
+              "name": "GET",
+              "parentSpanId": "",
+              "spanId": "xxxxx",
+              "status": {},
+              "traceId": "xxxxx"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/invalid"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:8080/invalid"
                   }
                 },
                 {

--- a/internal/test/e2e/databasesql/verify.bats
+++ b/internal/test/e2e/databasesql/verify.bats
@@ -15,18 +15,22 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   assert_equal "$result" "\"DELETE FROM contacts WHERE first_name = 'Mike'\""
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[4])
   assert_equal "$result" "\"DROP TABLE contacts\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[5])
+  assert_equal "$result" "\"syntax error\""
 }
 
 @test "${SCOPE} :: span name is set correctly" {
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[0])
-  assert_equal "$result" '"SELECT"'
+  assert_equal "$result" '"SELECT contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[1])
-  assert_equal "$result" '"INSERT"'
+  assert_equal "$result" '"INSERT contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[2])
-  assert_equal "$result" '"UPDATE"'
+  assert_equal "$result" '"UPDATE contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[3])
-  assert_equal "$result" '"DELETE"'
+  assert_equal "$result" '"DELETE contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[4])
+  assert_equal "$result" '"DB"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[5])
   assert_equal "$result" '"DB"'
 }
 
@@ -41,6 +45,8 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
   trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[5])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "${SCOPE} :: span ID present and valid in all spans" {
@@ -54,6 +60,8 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
   span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[5])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
 @test "${SCOPE} :: parent span ID present and valid in all spans" {
@@ -66,6 +74,8 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[3])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[4])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[5])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 

--- a/internal/test/e2e/databasesql/verify.bats
+++ b/internal/test/e2e/databasesql/verify.bats
@@ -5,22 +5,67 @@ load ../../test_helpers/utilities.sh
 SCOPE="go.opentelemetry.io/auto/database/sql"
 
 @test "${SCOPE} :: includes db.query.text attribute" {
-  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue")
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[0])
   assert_equal "$result" '"SELECT * FROM contacts"'
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[1])
+  assert_equal "$result" "\"INSERT INTO contacts (first_name) VALUES ('Mike')\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[2])
+  assert_equal "$result" "\"UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[3])
+  assert_equal "$result" "\"DELETE FROM contacts WHERE first_name = 'Mike'\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[4])
+  assert_equal "$result" "\"DROP TABLE contacts\""
+}
+
+@test "${SCOPE} :: span name is set correctly" {
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[0])
+  assert_equal "$result" '"SELECT"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[1])
+  assert_equal "$result" '"INSERT"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[2])
+  assert_equal "$result" '"UPDATE"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[3])
+  assert_equal "$result" '"DELETE"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[4])
+  assert_equal "$result" '"DB"'
 }
 
 @test "${SCOPE} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId")
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[0])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[1])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[2])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[3])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "${SCOPE} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId")
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[0])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[1])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[2])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[3])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
 @test "${SCOPE} :: parent span ID present and valid in all spans" {
-  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId")
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[0])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[1])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[2])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[3])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }
 


### PR DESCRIPTION
Ref #743 

From the [semconv for db spans](https://github.com/open-telemetry/semantic-conventions/blob/e0e93bad394a15161af7942d65d197defac7b88b/docs/database/database-spans.md#name):

```
Database spans MUST follow the overall [guidelines for span names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.37.0/specification/trace/api.md#span).

The span name SHOULD be {db.query.summary} if a summary is available.

If no summary is available, the span name SHOULD be {db.operation.name} {target} provided that a (low-cardinality) db.operation.name is available (see below for the exact definition of the [{target}](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#target-placeholder) placeholder).

If a (low-cardinality) db.operation.name is not available, database span names SHOULD default to the [{target}](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#target-placeholder).

If neither {db.operation.name} nor {target} are available, span name SHOULD be {db.system}.

Semantic conventions for individual database systems MAY specify different span name format.

The {target} SHOULD describe the entity that the operation is performed against and SHOULD adhere to one of the following values, provided they are accessible:

db.collection.name SHOULD be used for data manipulation operations or operations on a database collection.
db.namespace SHOULD be used for operations on a specific database namespace.
server.address:server.port SHOULD be used for other operations not targeting any specific database(s) or collection(s)
If a corresponding {target} value is not available for a specific operation, the instrumentation SHOULD omit the {target}. For example, for an operation describing SQL query on an anonymous table like SELECT * FROM (SELECT * FROM table) t, span name should be SELECT.
```

We don't have `collection` (table), `namespace`, or `server.address` readily available (right now), but we can at least parse certain operations. We can also support more over time. So this gets us at least a couple useful span names besides `DB` (fallback for unsupported operations)

This means we can also set [`db.operation.name`](https://github.com/open-telemetry/semantic-conventions/blob/e0e93bad394a15161af7942d65d197defac7b88b/docs/database/sql.md#attributes) with that same value when it is available.