### PR TITLE
Test SDK TracerProvider

### DIFF
--- a/sdk/trace.go
+++ b/sdk/trace.go
@@ -20,30 +20,6 @@ import (
 	"go.opentelemetry.io/auto/sdk/internal/telemetry"
 )
 
-// TracerProvider returns an auto-instrumentable [trace.TracerProvider].
-//
-// If an [go.opentelemetry.io/auto.Instrumentation] is configured to instrument
-// the process using the returned TracerProvider, all of the telemetry it
-// produces will be processed and handled by that Instrumentation. By default,
-// if no Instrumentation instruments the TracerProvider it will not generate
-// any trace telemetry.
-func TracerProvider() trace.TracerProvider { return tracerProviderInstance }
-
-var tracerProviderInstance = tracerProvider{}
-
-type tracerProvider struct{ noop.TracerProvider }
-
-var _ trace.TracerProvider = tracerProvider{}
-
-func (p tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
-	cfg := trace.NewTracerConfig(opts...)
-	return tracer{
-		name:      name,
-		version:   cfg.InstrumentationVersion(),
-		schemaURL: cfg.SchemaURL(),
-	}
-}
-
 type tracer struct {
 	noop.Tracer
 

--- a/sdk/trace_test.go
+++ b/sdk/trace_test.go
@@ -477,7 +477,7 @@ func TestSpanTracerProvider(t *testing.T) {
 	var s span
 
 	got := s.TracerProvider()
-	assert.IsType(t, tracerProvider{}, got)
+	assert.IsType(t, &tracerProvider{}, got)
 }
 
 type spanBuilder struct {

--- a/sdk/tracer_provider.go
+++ b/sdk/tracer_provider.go
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sdk
+
+import (
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// TracerProvider returns an auto-instrumentable [trace.TracerProvider].
+//
+// If an [go.opentelemetry.io/auto.Instrumentation] is configured to instrument
+// the process using the returned TracerProvider, all of the telemetry it
+// produces will be processed and handled by that Instrumentation. By default,
+// if no Instrumentation instruments the TracerProvider it will not generate
+// any trace telemetry.
+func TracerProvider() trace.TracerProvider { return tracerProviderInstance }
+
+var tracerProviderInstance = new(tracerProvider)
+
+type tracerProvider struct{ noop.TracerProvider }
+
+var _ trace.TracerProvider = tracerProvider{}
+
+func (p tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	cfg := trace.NewTracerConfig(opts...)
+	return tracer{
+		name:      name,
+		version:   cfg.InstrumentationVersion(),
+		schemaURL: cfg.SchemaURL(),
+	}
+}

--- a/sdk/tracer_provider_test.go
+++ b/sdk/tracer_provider_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sdk
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTracerProviderInstance(t *testing.T) {
+	t.Parallel()
+
+	tp0, tp1 := TracerProvider(), TracerProvider()
+
+	assert.Same(t, tracerProviderInstance, tp0)
+	assert.Same(t, tracerProviderInstance, tp1)
+}
+
+func TestTracerProviderConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 10
+
+	run := func(tp trace.TracerProvider) <-chan struct{} {
+		done := make(chan struct{})
+		go func(tp trace.TracerProvider) {
+			defer close(done)
+
+			var wg sync.WaitGroup
+			for i := 0; i < goroutines; i++ {
+				wg.Add(1)
+				go func(name, version string) {
+					defer wg.Done()
+					_ = tp.Tracer(name, trace.WithInstrumentationVersion(version))
+				}("tracer"+strconv.Itoa(i%4), strconv.Itoa(i%2))
+			}
+
+			wg.Wait()
+		}(tp)
+		return done
+	}
+
+	assert.NotPanics(t, func() {
+		done0, done1 := run(TracerProvider()), run(TracerProvider())
+
+		<-done0
+		<-done1
+	})
+}


### PR DESCRIPTION
- Move the tracerProvider type and related functionality to its own file to help discoverability.
- Use a singleton instance of the tracerProvider for tracerProviderInstance instead of having a new value created each call to TracerProvider.
- Test the singleton nature of TracerProvider.
- Test the concurrent safe behavior of the provided TracerProvider (part of #1297).