### PR TITLE
Move `spanKind` to `tracer.go`

### DIFF
--- a/sdk/trace.go
+++ b/sdk/trace.go
@@ -21,22 +21,6 @@ import (
 	"go.opentelemetry.io/auto/sdk/internal/telemetry"
 )
 
-func spanKind(kind trace.SpanKind) telemetry.SpanKind {
-	switch kind {
-	case trace.SpanKindInternal:
-		return telemetry.SpanKindInternal
-	case trace.SpanKindServer:
-		return telemetry.SpanKindServer
-	case trace.SpanKindClient:
-		return telemetry.SpanKindClient
-	case trace.SpanKindProducer:
-		return telemetry.SpanKindProducer
-	case trace.SpanKindConsumer:
-		return telemetry.SpanKindConsumer
-	}
-	return telemetry.SpanKind(0) // undefined.
-}
-
 type span struct {
 	noop.Span
 

--- a/sdk/trace_test.go
+++ b/sdk/trace_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"math"
 	"strconv"
 	"sync"
 	"testing"
@@ -264,24 +263,6 @@ func TestSpanCreation(t *testing.T) {
 
 			tc.Eval(t, c, s)
 		})
-	}
-}
-
-func TestSpanKindTransform(t *testing.T) {
-	tests := map[trace.SpanKind]telemetry.SpanKind{
-		trace.SpanKind(-1):          telemetry.SpanKind(0),
-		trace.SpanKindUnspecified:   telemetry.SpanKind(0),
-		trace.SpanKind(math.MaxInt): telemetry.SpanKind(0),
-
-		trace.SpanKindInternal: telemetry.SpanKindInternal,
-		trace.SpanKindServer:   telemetry.SpanKindServer,
-		trace.SpanKindClient:   telemetry.SpanKindClient,
-		trace.SpanKindProducer: telemetry.SpanKindProducer,
-		trace.SpanKindConsumer: telemetry.SpanKindConsumer,
-	}
-
-	for in, want := range tests {
-		assert.Equal(t, want, spanKind(in), in.String())
 	}
 }
 

--- a/sdk/tracer.go
+++ b/sdk/tracer.go
@@ -94,3 +94,19 @@ func (t tracer) traces(ctx context.Context, name string, cfg trace.SpanConfig, s
 		},
 	}, span
 }
+
+func spanKind(kind trace.SpanKind) telemetry.SpanKind {
+	switch kind {
+	case trace.SpanKindInternal:
+		return telemetry.SpanKindInternal
+	case trace.SpanKindServer:
+		return telemetry.SpanKindServer
+	case trace.SpanKindClient:
+		return telemetry.SpanKindClient
+	case trace.SpanKindProducer:
+		return telemetry.SpanKindProducer
+	case trace.SpanKindConsumer:
+		return telemetry.SpanKindConsumer
+	}
+	return telemetry.SpanKind(0) // undefined.
+}

--- a/sdk/tracer_test.go
+++ b/sdk/tracer_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/auto/sdk/internal/telemetry"
 	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/auto/sdk/internal/telemetry"
 )
 
 const tName = "tracer.name"

--- a/sdk/tracer_test.go
+++ b/sdk/tracer_test.go
@@ -5,15 +5,35 @@ package sdk
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/auto/sdk/internal/telemetry"
 	"go.opentelemetry.io/otel/trace"
 )
 
 const tName = "tracer.name"
+
+func TestSpanKindTransform(t *testing.T) {
+	tests := map[trace.SpanKind]telemetry.SpanKind{
+		trace.SpanKind(-1):          telemetry.SpanKind(0),
+		trace.SpanKindUnspecified:   telemetry.SpanKind(0),
+		trace.SpanKind(math.MaxInt): telemetry.SpanKind(0),
+
+		trace.SpanKindInternal: telemetry.SpanKindInternal,
+		trace.SpanKindServer:   telemetry.SpanKindServer,
+		trace.SpanKindClient:   telemetry.SpanKindClient,
+		trace.SpanKindProducer: telemetry.SpanKindProducer,
+		trace.SpanKindConsumer: telemetry.SpanKindConsumer,
+	}
+
+	for in, want := range tests {
+		assert.Equal(t, want, spanKind(in), in.String())
+	}
+}
 
 func TestTracerStartPropagatesOrigCtx(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
The spanKind func is used by `tracer.Start` and nowhere else. Move its definition closer to its use and similarly adjust the tests.