### PR TITLE
Release v0.18.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.18.0-alpha] - 2024-11-20
+
 ### Changed
 
 - Split the functionality of `Instrumentation.Run` to `Instrumentation.Load` and `Instrumentation.Run`.
@@ -496,7 +498,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.17.0-alpha...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.18.0-alpha...HEAD
+[v0.18.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.18.0-alpha
 [v0.17.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.17.0-alpha
 [v0.16.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.16.0-alpha
 [v0.15.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.15.0-alpha

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,7 +7,7 @@ Auto-instrumentation can be configured to capture the telemetry sent to the
 
 Supported versions of [`otel`]:
 
-- `v0.14.0` to `v1.30.0`
+- `v0.14.0` to `v1.32.0`
 
 [`otel`]: https://pkg.go.dev/go.opentelemetry.io/otel
 

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/database/sql",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {
@@ -79,7 +79,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/github.com/segmentio/kafka-go",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {
@@ -53,7 +53,7 @@
           "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
-            "version": "v0.17.0-alpha"
+            "version": "v0.18.0-alpha"
           },
           "spans": [
             {

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -36,7 +36,7 @@
           {
             "key": "telemetry.distro.version",
             "value": {
-              "stringValue": "v0.17.0-alpha"
+              "stringValue": "v0.18.0-alpha"
             }
           },
           {

--- a/sdk/internal/telemetry/test/go.mod
+++ b/sdk/internal/telemetry/test/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/auto/sdk/telemetry/test
+module go.opentelemetry.io/auto/sdk/internal/telemetry/test
 
 go 1.22.0
 

--- a/version.go
+++ b/version.go
@@ -5,5 +5,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.17.0-alpha"
+	return "v0.18.0-alpha"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,11 +3,11 @@
 
 module-sets:
   auto:
-    version: v0.17.0-alpha
+    version: v0.18.0-alpha
     modules:
       - go.opentelemetry.io/auto
   sdk:
-    version: v0.2.0-alpha
+    version: v1.0.0
     modules:
       - go.opentelemetry.io/auto/sdk
 excluded-modules:


### PR DESCRIPTION
This release includes the first `v1` stable release of the `go.opentelemetry.io/auto/sdk` module.

### Changed

- Split the functionality of `Instrumentation.Run` to `Instrumentation.Load` and `Instrumentation.Run`. `Load` will report any errors in the loading and attaching phase of the probes. ([#1245](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1245))

### Added

- Include `server.address` and `server.port` in gRPC spans (>=v1.60.0). ([#1242](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1242))
- Support Go standard libraries for 1.22.9 and 1.23.3. ([#1250](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1250))
- Support `google.golang.org/grpc` `1.68.0`. ([#1251](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1251))
- Support `golang.org/x/net` `0.31.0`. ([#1254](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1254))
- Support `go.opentelemetry.io/otel@v1.32.0`. ([#1302](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1302))

### Fixed

- Don't include `db.query.text` attribute in `database/sql` if the query string is empty or not collected. ([#1246](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1246))
- Handle a `ConfigProvider` which doesn't provide a sampling config in the initial configuration by applying the default sampler. ([#1292](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1292))

### Removed

- The deprecated `go.opentelemetry.io/auto/sdk/telemetry` package is removed. ([#1252](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1252))
- The deprecated `go.opentelemetry.io/auto/sdk/telemetry/test` module is removed. ([#1252](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1252))
- Remove the `WithLoadedIndicator` `InstrumentationOption` since the `Instrumentation.Load` will indicate whether the probes are loaded in a synchronous way.  ([#1245](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1245))