### PR TITLE
Renovate: update indirect tools dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,12 +17,6 @@
       "enabled": true
     },
     {
-      "matchFileNames": ["internal/tools/**"],
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
-      "enabled": false
-    },
-    {
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
       "groupName": "googleapis"
     },


### PR DESCRIPTION
Similar to [otel-go](https://github.com/open-telemetry/opentelemetry-go/pull/6038) and [contrib](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6444), have renovate update our indirect dependencies in the tools package. This addresses security fixes when they arise and it should fix the failure of renovate to correctly run `go mod tidy` on PRs (it currently skips this directory when it would only update indirect dependencies).