### PR TITLE
fix typo

### DIFF
--- a/examples/kafka-go/docker-compose.yml
+++ b/examples/kafka-go/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
       - OTEL_GO_AUTO_TARGET_EXE=/app/consumer
-      - OTEL_SERVICE_NAME=kkafkaconsumer
+      - OTEL_SERVICE_NAME=kafkaconsumer
       - OTEL_PROPAGATORS=tracecontext,baggage
       - OTEL_GO_AUTO_SHOW_VERIFIER_LOG=true
     volumes:


### PR DESCRIPTION
Remove double `k` in service.name of kafka-go demo