### PR TITLE
Call NewSpanExporter without checking OTLP_TRACES_EXPORTER environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ## [Unreleased]
 
 ### Added
+
 - Update `httpPlusdb` demo with adding `OTEL_GO_AUTO_PARSE_DB_STATEMENT` env variable ([#1523](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1523))
 - Support `SELECT`, `INSERT`, `UPDATE`, and `DELETE` for database span names and `db.operation.name` attribute. ([#1253](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1253))
 - Support the full tracing API with the `otelglobal` probe. ([#1405](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1405))
@@ -22,6 +23,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Include gRPC error message for client spans. ([#1528](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1528))
 - Support `golang.org/x/net` `0.34.0`. ([#1552](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1552))
 - Support `google.golang.org/grpc` `1.71.0-dev`. ([#1467](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1467))
+
+### Fixed
+
+- Respect `OTEL_EXPORTER_OTLP_PROTOCOL` when `OTEL_TRACES_EXPORTER` is not set. ([#1572](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1572))
 
 ## [v0.19.0-alpha] - 2024-12-05
 
@@ -66,7 +71,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - The deprecated `go.opentelemetry.io/auto/sdk/telemetry` package is removed. ([#1252](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1252))
 - The deprecated `go.opentelemetry.io/auto/sdk/telemetry/test` module is removed. ([#1252](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1252))
-- Remove the `WithLoadedIndicator` `InstrumentationOption` since the `Instrumentation.Load` will indicate whether the probes are loaded in a synchronous way.  ([#1245](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1245))
+- Remove the `WithLoadedIndicator` `InstrumentationOption` since the `Instrumentation.Load` will indicate whether the probes are loaded in a synchronous way. ([#1245](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1245))
 
 ## [v0.17.0-alpha] - 2024-11-05
 
@@ -114,7 +119,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Support Go `v1.22.6`. ([#988](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/988))
 - Support `golang.org/x/net` `v0.28.0`. ([#988](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/988))
 - Support `google.golang.org/grpc` `1.67.0-dev`. ([#1007](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1007))
-- Support Go `1.23.0`.  ([#1007](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1007))
+- Support Go `1.23.0`. ([#1007](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1007))
 - Introduce `config.Provider` as an option to set the initial configuration and update it in runtime. ([#1010](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1010))
 - Support `go.opentelemetry.io/otel@v1.29.0`. ([#1032](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1032))
 - Support `google.golang.org/grpc` `1.66.0`. ([#1046](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1046))
@@ -552,5 +557,4 @@ This is the first release of OpenTelemetry Go Automatic Instrumentation.
 [v0.2.1-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.2.1-alpha
 [v0.2.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.2.0-alpha
 [v0.1.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.1.0-alpha
-
 [Go 1.22]: https://go.dev/doc/go1.22

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ retract (
 
 require (
 	github.com/cilium/ebpf v0.17.1
+	github.com/go-logr/stdr v1.2.2
 	github.com/hashicorp/go-version v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
@@ -26,6 +27,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.23.0
 	go.opentelemetry.io/contrib/exporters/autoexport v0.58.0
 	go.opentelemetry.io/otel v1.33.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0
 	go.opentelemetry.io/otel/sdk v1.33.0
 	go.opentelemetry.io/otel/trace v1.33.0
@@ -41,7 +43,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
@@ -61,7 +62,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.9.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.33.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.33.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.55.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.9.0 // indirect

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -37,9 +37,6 @@ const (
 	// envResourceAttrKey is the key for the environment variable value containing
 	// OpenTelemetry Resource attributes.
 	envResourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES"
-	// envTracesExportersKey is the key for the environment variable value
-	// containing what OpenTelemetry trace exporter to use.
-	envTracesExportersKey = "OTEL_TRACES_EXPORTER"
 	// envOtelGlobalImplKey is the key for the environment variable value enabling to opt-in for the
 	// OpenTelemetry global implementation. It should be a boolean value.
 	envOtelGlobalImplKey = "OTEL_GO_AUTO_GLOBAL"
@@ -408,14 +405,11 @@ func WithEnv() InstrumentationOption {
 		if v, ok := lookupEnv(envTargetExeKey); ok {
 			c.target = process.TargetArgs{ExePath: v}
 		}
-		if _, ok := lookupEnv(envTracesExportersKey); ok {
-			// Don't track the lookup value because autoexport does not provide
-			// a way to just pass the environment value currently. Just use
-			// NewSpanExporter which will re-read this value.
-
+		{
 			var e error
 			// NewSpanExporter will use an OTLP (HTTP/protobuf) exporter as the
-			// default. This is the OTel recommended default.
+			// default, unless OTLP_TRACES_EXPORTER is set. This is the OTel
+			// recommended default.
 			c.traceExp, e = autoexport.NewSpanExporter(ctx)
 			err = errors.Join(err, e)
 		}

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -405,14 +405,14 @@ func WithEnv() InstrumentationOption {
 		if v, ok := lookupEnv(envTargetExeKey); ok {
 			c.target = process.TargetArgs{ExePath: v}
 		}
-		{
-			var e error
-			// NewSpanExporter will use an OTLP (HTTP/protobuf) exporter as the
-			// default, unless OTLP_TRACES_EXPORTER is set. This is the OTel
-			// recommended default.
-			c.traceExp, e = autoexport.NewSpanExporter(ctx)
-			err = errors.Join(err, e)
-		}
+
+		var e error
+		// NewSpanExporter will use an OTLP (HTTP/protobuf) exporter as the
+		// default, unless OTLP_TRACES_EXPORTER is set. This is the OTel
+		// recommended default.
+		c.traceExp, e = autoexport.NewSpanExporter(ctx)
+		err = errors.Join(err, e)
+
 		if name, attrs, ok := lookupResourceData(); ok {
 			c.serviceName = name
 			c.additionalResAttrs = append(c.additionalResAttrs, attrs...)

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,6 +95,16 @@ func TestWithEnv(t *testing.T) {
 		t.Setenv(envLogLevelKey, "invalid")
 		_, err = newInstConfig(ctx, opts)
 		require.ErrorContains(t, err, `parse log level "invalid"`)
+	})
+
+	// Test that autoexport.NewSpanExporter works when OTEL_TRACES_EXPORTER is
+	// not set
+	t.Run("With OTEL_TRACES_EXPORTER not set", func(t *testing.T) {
+		os.Unsetenv("OTEL_TRACES_EXPORTER")
+		c, err := newInstConfig(context.Background(), []InstrumentationOption{WithEnv()})
+
+		require.NoError(t, err)
+		assert.NotNil(t, c.traceExp)
 	})
 }
 

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -4,16 +4,21 @@
 package auto
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"log/slog"
 	"os"
 	"testing"
 
+	"github.com/go-logr/stdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe/sampling"
@@ -98,13 +103,23 @@ func TestWithEnv(t *testing.T) {
 	})
 
 	// Test that autoexport.NewSpanExporter works when OTEL_TRACES_EXPORTER is
-	// not set
+	// not set and OTEL_EXPORTER_OTLP_PROTOCOL is set to 'grpc'
 	t.Run("With OTEL_TRACES_EXPORTER not set", func(t *testing.T) {
 		os.Unsetenv("OTEL_TRACES_EXPORTER")
+		t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 		c, err := newInstConfig(context.Background(), []InstrumentationOption{WithEnv()})
 
 		require.NoError(t, err)
-		assert.NotNil(t, c.traceExp)
+		require.NotNil(t, c.traceExp)
+		require.IsType(t, &otlptrace.Exporter{}, c.traceExp)
+		exp := c.traceExp.(*otlptrace.Exporter)
+		var buf bytes.Buffer
+		logger := stdr.New(log.New(&buf, "", log.LstdFlags))
+		logger.Info("", "exporter", exp)
+		got, err := io.ReadAll(&buf)
+		require.NoError(t, err)
+		// "otlphttphttp" should be "otlptracegrpc". This is a bug upstream.
+		assert.Contains(t, string(got), "otlphttpgrpc")
 	})
 }
 


### PR DESCRIPTION
Currently if `OTEL_TRACES_EXPORTER` is not defined, then the trace exporter is always set to HTTP, regardless of the value of `OTEL_EXPORTER_OTLP_PROTOCOL`.  This is because there is a check to see if `OTEL_TRACES_EXPORTER` is set before calling `autoexport.NewSpanExporter`.

This change removes that check and adds a test to ensure that `autoexport.NewSpanExporter` still works without `OTEL_TRACES_EXPORTER` defined. I have left the fallback code in place [here](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/instrumentation.go#L216-L221) so that if `OTEL_EXPORTER_OTLP_PROTOCOL` has an invalid value (or NewSpanExporter returns nil for any other reason) the http exporter will be selected (which is the current behaviour).