### PR TITLE
Makefile: docker-build dep of fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,7 @@ fixture-otelglobal: fixtures/otelglobal
 fixture-autosdk: fixtures/autosdk
 fixture-kafka-go: fixtures/kafka-go
 fixtures/%: LIBRARY=$*
-fixtures/%:
-	$(MAKE) docker-build
+fixtures/%: docker-build
 	if [ -f ./internal/test/e2e/$(LIBRARY)/build.sh ]; then \
 		./internal/test/e2e/$(LIBRARY)/build.sh; \
 	else \


### PR DESCRIPTION
Instead of calling make for docker-build within fixtures/%, have that target be a dependency run prior to fixtures.