### PR TITLE
Rename TargetDetails.Libraries to Modules

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -111,7 +111,7 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 		"target process analysis completed",
 		"pid", td.PID,
 		"go_version", td.GoVersion,
-		"dependencies", td.Libraries,
+		"dependencies", td.Modules,
 		"total_functions_found", len(td.Functions),
 	)
 	mngr.FilterUnusedProbes(td)

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
@@ -254,7 +254,7 @@ type tracerIDContainsSchemaURL struct{}
 var schemaAddedToTracerKeyVer = version.Must(version.NewVersion("1.28.0"))
 
 func (c tracerIDContainsSchemaURL) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries["go.opentelemetry.io/otel"]
+	ver, ok := td.Modules["go.opentelemetry.io/otel"]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}
@@ -270,7 +270,7 @@ var scopeAttributesAddedToTracerKeyVer = version.Must(version.NewVersion("1.32.0
 type tracerIDContainsScopeAttributes struct{}
 
 func (c tracerIDContainsScopeAttributes) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries["go.opentelemetry.io/otel"]
+	ver, ok := td.Modules["go.opentelemetry.io/otel"]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
@@ -41,7 +41,7 @@ var (
 type writeStatusConst struct{}
 
 func (w writeStatusConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries[pkg]
+	ver, ok := td.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -207,7 +207,7 @@ type framePosConst struct{}
 var paramChangeVer = version.Must(version.NewVersion("1.60.0"))
 
 func (c framePosConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries[pkg]
+	ver, ok := td.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}
@@ -223,7 +223,7 @@ var (
 )
 
 func (w serverAddrConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries[pkg]
+	ver, ok := td.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/manager_test.go
+++ b/internal/pkg/instrumentation/manager_test.go
@@ -40,7 +40,7 @@ func TestProbeFiltering(t *testing.T) {
 			PID:               1,
 			Functions:         []*binary.Func{},
 			GoVersion:         ver,
-			Libraries:         map[string]*version.Version{},
+			Modules:           map[string]*version.Version{},
 			AllocationDetails: nil,
 		}
 		m.FilterUnusedProbes(&td)
@@ -58,7 +58,7 @@ func TestProbeFiltering(t *testing.T) {
 			PID:               1,
 			Functions:         httpFuncs,
 			GoVersion:         ver,
-			Libraries:         map[string]*version.Version{},
+			Modules:           map[string]*version.Version{},
 			AllocationDetails: nil,
 		}
 		m.FilterUnusedProbes(&td)
@@ -77,7 +77,7 @@ func TestProbeFiltering(t *testing.T) {
 			PID:               1,
 			Functions:         httpFuncs,
 			GoVersion:         ver,
-			Libraries:         map[string]*version.Version{},
+			Modules:           map[string]*version.Version{},
 			AllocationDetails: nil,
 		}
 		m.FilterUnusedProbes(&td)
@@ -97,7 +97,7 @@ func TestProbeFiltering(t *testing.T) {
 			PID:               1,
 			Functions:         httpFuncs,
 			GoVersion:         ver,
-			Libraries:         map[string]*version.Version{},
+			Modules:           map[string]*version.Version{},
 			AllocationDetails: nil,
 		}
 		m.FilterUnusedProbes(&td)

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -169,7 +169,7 @@ func (i *Base[BPFObj, BPFEvent]) loadUprobes(exec *link.Executable, td *process.
 	for _, up := range i.Uprobes {
 		var skip bool
 		for _, pc := range up.PackageConstrainsts {
-			if pc.Constraints.Check(td.Libraries[pc.Package]) {
+			if pc.Constraints.Check(td.Modules[pc.Package]) {
 				continue
 			}
 
@@ -461,7 +461,7 @@ type StructFieldConst struct {
 // version of the struct field module is known. If it is not, an error is
 // returned.
 func (c StructFieldConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Libraries[c.Val.ModPath]
+	ver, ok := td.Modules[c.Val.ModPath]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", c.Val.ModPath)
 	}
@@ -483,7 +483,7 @@ type StructFieldConstMinVersion struct {
 // injected.
 func (c StructFieldConstMinVersion) InjectOption(td *process.TargetDetails) (inject.Option, error) {
 	sf := c.StructField
-	ver, ok := td.Libraries[sf.Val.ModPath]
+	ver, ok := td.Modules[sf.Val.ModPath]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", sf.Val.ModPath)
 	}

--- a/internal/pkg/instrumentation/testutils/testutils.go
+++ b/internal/pkg/instrumentation/testutils/testutils.go
@@ -36,13 +36,13 @@ func ProbesLoad(t *testing.T, p TestProbe, libs map[string]*version.Version) {
 			StartAddr: 140434497441792,
 			EndAddr:   140434497507328,
 		},
-		Libraries: map[string]*version.Version{
+		Modules: map[string]*version.Version{
 			"std": testGoVersion,
 		},
 		GoVersion: testGoVersion,
 	}
 	for k, v := range libs {
-		td.Libraries[k] = v
+		td.Modules[k] = v
 	}
 
 	err = bpffs.Mount(td)

--- a/internal/pkg/process/analyze.go
+++ b/internal/pkg/process/analyze.go
@@ -21,7 +21,7 @@ type TargetDetails struct {
 	PID               int
 	Functions         []*binary.Func
 	GoVersion         *version.Version
-	Libraries         map[string]*version.Version
+	Modules           map[string]*version.Version
 	AllocationDetails *AllocationDetails
 }
 
@@ -76,16 +76,16 @@ func (a *Analyzer) Analyze(pid int, relevantFuncs map[string]interface{}) (*Targ
 		return nil, err
 	}
 	result.GoVersion = goVersion
-	result.Libraries = make(map[string]*version.Version, len(a.BuildInfo.Deps)+1)
+	result.Modules = make(map[string]*version.Version, len(a.BuildInfo.Deps)+1)
 	for _, dep := range a.BuildInfo.Deps {
 		depVersion, err := version.NewVersion(dep.Version)
 		if err != nil {
 			a.logger.Error("parsing dependency version", "error", err, "dependency", dep)
 			continue
 		}
-		result.Libraries[dep.Path] = depVersion
+		result.Modules[dep.Path] = depVersion
 	}
-	result.Libraries["std"] = goVersion
+	result.Modules["std"] = goVersion
 
 	funcs, err := a.findFunctions(elfF, relevantFuncs)
 	if err != nil {


### PR DESCRIPTION
Clarifies, in the Go parlance, what the TargetDetails field contains: a map of module names to versions.