### PR TITLE
Rename Manifest.Id to Manifest.ID

### DIFF
--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) validateProbeDependents(id probe.ID, symbols []probe.FunctionS
 }
 
 func (m *Manager) registerProbe(p probe.Probe) error {
-	id := p.Manifest().Id
+	id := p.Manifest().ID
 	if _, exists := m.probes[id]; exists {
 		return fmt.Errorf("library %s registered twice, aborting", id)
 	}

--- a/internal/pkg/instrumentation/manager_load_test.go
+++ b/internal/pkg/instrumentation/manager_load_test.go
@@ -35,7 +35,7 @@ func TestLoadProbes(t *testing.T) {
 				offsets[f.ModPath] = ver
 			}
 		}
-		t.Run(p.Manifest().Id.String(), func(t *testing.T) {
+		t.Run(p.Manifest().ID.String(), func(t *testing.T) {
 			testProbe, ok := p.(testutils.TestProbe)
 			assert.True(t, ok)
 			testutils.ProbesLoad(t, testProbe, offsets)

--- a/internal/pkg/instrumentation/probe/manifest.go
+++ b/internal/pkg/instrumentation/probe/manifest.go
@@ -21,7 +21,7 @@ type FunctionSymbol struct {
 // Manifest contains information about a package being instrumented.
 type Manifest struct {
 	// ID is a unique identifier for the probe.
-	Id ID
+	ID ID
 
 	// StructFields are the struct fields in an instrumented package that are
 	// used for instrumentation.
@@ -66,7 +66,7 @@ func NewManifest(id ID, structfields []structfield.ID, symbols []FunctionSymbol)
 	})
 
 	return Manifest{
-		Id:           id,
+		ID:           id,
 		StructFields: structfields,
 		Symbols:      symbols,
 	}

--- a/internal/pkg/instrumentation/probe/manifest_test.go
+++ b/internal/pkg/instrumentation/probe/manifest_test.go
@@ -44,7 +44,7 @@ func TestNewManifest(t *testing.T) {
 		[]FunctionSymbol{fs(d), fs(a), fs(c), fs(b)},
 	)
 	want := Manifest{
-		Id:           ID{spanKind, pkg},
+		ID:           ID{spanKind, pkg},
 		StructFields: []structfield.ID{sAAAA, sAAAB, sAAAC, sAABA, sAABB, sAABC, sABAA, sBAAA},
 		Symbols:      []FunctionSymbol{fs(a), fs(b), fs(c), fs(d)},
 	}


### PR DESCRIPTION
Follow the [Go code review recommendation](https://go.dev/wiki/CodeReviewComments#initialisms), the [Google Go style guide](https://google.github.io/styleguide/go/decisions#initialisms), and our existing naming conventions[^1][^2][^3][^4][^5][^6][^7][^8][^9] regarding `ID` and rename `Manifest.Id` to `ID`.

[^1]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/provider.go#L16
[^2]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/sampling.go#L27
[^3]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/sampling.go#L30
[^4]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/instrumentation/probe/sampling/sampling.go#L23
[^5]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/instrumentation/probe/sampling/sampling.go#L29
[^6]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/instrumentation/probe/sampling/sampling.go#L45
[^7]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/structfield/structfield.go#L207
[^8]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/instrumentation/config.go#L15
[^9]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/5ccf0c1ed7ba911a7d7c2037ffeb18399081756a/internal/pkg/instrumentation/probe/probe.go#L59