### PR TITLE
Renovate: ignore updates for examples/rolldice/user

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
       "enabled": true
     },
     {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/auto/examples/rolldice/user"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
       "groupName": "googleapis"
     },


### PR DESCRIPTION
The `examples/rolldice/frontend` service uses a relative import of this package. There is no need to updated it as it will not be released with a semver version.