### PR TITLE
Add a slim Docker image for testing

### DIFF
--- a/.github/workflows/e2e/k8s/sample-job.yml
+++ b/.github/workflows/e2e/k8s/sample-job.yml
@@ -26,7 +26,7 @@ spec:
       - name: auto-instrumentation
         image: otel-go-instrumentation
         imagePullPolicy: IfNotPresent
-        command: ["/otel-go-instrumentation", "-global-impl", "-log-level=debug"]
+        args: ["-global-impl", "-log-level=debug"]
         env:
         - name: OTEL_GO_AUTO_TARGET_EXE
           value: /usr/local/bin/app

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -14,9 +14,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Install build dependencies
+        run: sudo apt-get install -y clang llvm libbpf-dev
       - name: Build auto-instrumentation
         run: |
-          IMG=otel-go-instrumentation:latest make docker-build
+          IMG=otel-go-instrumentation:latest make docker-build-test
           docker save otel-go-instrumentation:latest -o otel-go-instrumentation.tar
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ docker-build:
 docker-build-base:
 	docker buildx build -t $(IMG_NAME_BASE) --target base .
 
+.PHONY: docker-test
+docker-build-test: generate
+	docker buildx build -t $(IMG_NAME) -f test.Dockerfile .
+
 .PHONY: sample-app/nethttp sample-app/gin sample-app/databasesql sample-app/nethttp-custom sample-app/otelglobal sample-app/autosdk sample-app/kafka-go
 sample-app/%: LIBRARY=$*
 sample-app/%:
@@ -178,7 +182,7 @@ fixture-otelglobal: fixtures/otelglobal
 fixture-autosdk: fixtures/autosdk
 fixture-kafka-go: fixtures/kafka-go
 fixtures/%: LIBRARY=$*
-fixtures/%: docker-build sample-app/%
+fixtures/%: docker-build-test sample-app/%
 	kind create cluster
 	kind load docker-image otel-go-instrumentation sample-app
 	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ docker-build:
 docker-build-base:
 	docker buildx build -t $(IMG_NAME_BASE) --target base .
 
-.PHONY: docker-test
+.PHONY: docker-build-test
 docker-build-test: generate
 	docker buildx build -t $(IMG_NAME) -f test.Dockerfile .
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.23.4-bookworm@sha256:e4906bc13f563c90ea22151e831cda45d58838f2bee18823f0bcc717464ccfe5
 
-RUN apt-get update && apt-get install -y curl clang gcc llvm make libbpf-dev
-
 WORKDIR /usr/src/go.opentelemetry.io/auto/
 
 COPY go.mod go.sum ./

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.23.4-bookworm@sha256:e4906bc13f563c90ea22151e831cda45d58838f2bee18823f0bcc717464ccfe5
+
+RUN apt-get update && apt-get install -y curl clang gcc llvm make libbpf-dev
+
+WORKDIR /usr/src/go.opentelemetry.io/auto/
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg go mod download && go mod verify
+
+COPY . .
+
+ARG CGO_ENABLED=0
+
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+	CGO_ENABLED=$CGO_ENABLED \
+	go build -o /usr/local/bin/otel-go-instrumentation ./cli/...
+
+ENTRYPOINT ["/usr/local/bin/otel-go-instrumentation"]

--- a/test.Dockerfile.dockerignore
+++ b/test.Dockerfile.dockerignore
@@ -4,9 +4,6 @@
 # Ignore everything by default.
 *
 
-# Make tooling
-!/Makefile
-
 # Copyright requirements.
 !/LICENSE
 !/LICENSES

--- a/test.Dockerfile.dockerignore
+++ b/test.Dockerfile.dockerignore
@@ -1,0 +1,23 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Ignore everything by default.
+*
+
+# Make tooling
+!/Makefile
+
+# Copyright requirements.
+!/LICENSE
+!/LICENSES
+
+# Go
+!/go.sum
+!/go.mod
+!/*.go
+
+# Packages
+!/cli
+!/sdk
+!/internal/include/
+!/internal/pkg/


### PR DESCRIPTION
For testing purposes we only need the auto-instrumentation code (not tests, examples, docs, etc.). Add an equivalent Dockerfile to the base one that will exclude all these extraneous items.