### PR TITLE
chore: Clean up CONTRIBUTING.md approvers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,6 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 ### Approvers
 
-- [Aaron Clawson](https://github.com/MadVikingGod), LightStep
 - [Dinesh Gurumurthy](https://github.com/dineshg13), DataDog
 - [Nikola Grcevski](https://github.com/grcevski), Grafana Labs
 - [Robert Pająk](https://github.com/pellared), Splunk


### PR DESCRIPTION
Remove Aaron Clawson from approvers list. He was removed as an approver a while ago.