### PR TITLE
Fix database instrumentation for Go < 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Support Go `1.22.12`. ([#1743](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1743))
 - Support Go `1.23.6`. ([#1743](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1743))
 
+### Fixed
+
+- `database/sql` instrumentation for Go < `1.17`. (#1772)
+
 ## [v0.20.0] - 2025-01-29
 
 ### Added

--- a/internal/pkg/instrumentation/bpf/database/sql/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/database/sql/bpf/probe.bpf.c
@@ -69,7 +69,7 @@ int uprobe_queryDC(struct pt_regs *ctx) {
 
 // This instrumentation attaches uprobe to the following function:
 // func (db *DB) queryDC(ctx, txctx context.Context, dc *driverConn, releaseConn func(error), query string, args []any)
-UPROBE_RETURN(queryDC, struct sql_request_t, sql_events, events, 3, 0, true)
+UPROBE_RETURN(queryDC, struct sql_request_t, sql_events, events, 2, 0, true)
 
 // This instrumentation attaches uprobe to the following function:
 // func (db *DB) execDC(ctx context.Context, dc *driverConn, release func(error), query string, args []any)


### PR DESCRIPTION
Use the correct context argument position in the UPROBE_RETURN macro.

Fix #1581

Tested locally: https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/1581#issuecomment-2643822448