### PR TITLE
[chore] Use public Linux ARM64 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
   generate-and-test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, otel-linux-arm64]
+        os: [ ubuntu-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        os: [ ubuntu-latest, otel-linux-arm64]
+        os: [ ubuntu-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Currently, OpenTelemetry Go Automatic Instrumentation is tested for the followin
 | ------- | ---------- | ------------ |
 | Ubuntu  | 1.23       | amd64        |
 | Ubuntu  | 1.22       | amd64        |
+| Ubuntu  | 1.23       | arm64        |
+| Ubuntu  | 1.22       | arm64        |
 
 Automatic instrumentation should work on any Linux kernel above 4.4.
 


### PR DESCRIPTION
Handles https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

## Changes

Switches ARM64 runners to the public version.

## Notes

Already done in .NET, .NET Auto and rust. It will allow to remove private runners from otel org and execute whole pipeline on public forks.
OTek Go SDK PR: https://github.com/open-telemetry/opentelemetry-go/pull/6320