### PR TITLE
Rename `process.TargetDetails` to `process.Info`

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -47,7 +47,7 @@ const (
 // Instrumentation manages and controls all OpenTelemetry Go
 // auto-instrumentation.
 type Instrumentation struct {
-	target   *process.TargetDetails
+	target   *process.Info
 	analyzer *process.Analyzer
 	manager  *instrumentation.Manager
 

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -148,8 +148,8 @@ func WithOffset(key string, id structfield.ID, ver *semver.Version) Option {
 	return WithKeyValue(key, off.Offset)
 }
 
-func FindOffset(id structfield.ID, td *process.TargetDetails) (structfield.OffsetKey, error) {
-	fd, err := td.OpenExe()
+func FindOffset(id structfield.ID, info *process.Info) (structfield.OffsetKey, error) {
+	fd, err := info.OpenExe()
 	if err != nil {
 		return structfield.OffsetKey{}, err
 	}

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
@@ -257,8 +257,8 @@ type tracerIDContainsSchemaURL struct{}
 // https://github.com/open-telemetry/opentelemetry-go/pull/5426/files
 var schemaAddedToTracerKeyVer = semver.New(1, 28, 0, "", "")
 
-func (c tracerIDContainsSchemaURL) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Modules["go.opentelemetry.io/otel"]
+func (c tracerIDContainsSchemaURL) InjectOption(info *process.Info) (inject.Option, error) {
+	ver, ok := info.Modules["go.opentelemetry.io/otel"]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}
@@ -273,8 +273,8 @@ var scopeAttributesAddedToTracerKeyVer = semver.New(1, 32, 0, "", "")
 // tracerIDContainsScopeAttributes is a Probe Const defining whether the tracer key contains scope attributes.
 type tracerIDContainsScopeAttributes struct{}
 
-func (c tracerIDContainsScopeAttributes) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Modules["go.opentelemetry.io/otel"]
+func (c tracerIDContainsScopeAttributes) InjectOption(info *process.Info) (inject.Option, error) {
+	ver, ok := info.Modules["go.opentelemetry.io/otel"]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
@@ -41,8 +41,8 @@ var (
 
 type writeStatusConst struct{}
 
-func (w writeStatusConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Modules[pkg]
+func (w writeStatusConst) InjectOption(info *process.Info) (inject.Option, error) {
+	ver, ok := info.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -198,8 +198,8 @@ type framePosConst struct{}
 // https://github.com/grpc/grpc-go/pull/6716/files#diff-4058722211b8d52e2d5b0c0b7542059ed447a04017b69520d767e94a9493409eR334
 var paramChangeVer = semver.New(1, 60, 0, "", "")
 
-func (c framePosConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Modules[pkg]
+func (c framePosConst) InjectOption(info *process.Info) (inject.Option, error) {
+	ver, ok := info.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}
@@ -214,8 +214,8 @@ var (
 	serverAddr           = false
 )
 
-func (w serverAddrConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	ver, ok := td.Modules[pkg]
+func (w serverAddrConst) InjectOption(info *process.Info) (inject.Option, error) {
+	ver, ok := info.Modules[pkg]
 	if !ok {
 		return nil, fmt.Errorf("unknown module version: %s", pkg)
 	}

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -151,15 +151,15 @@ var (
 	isPatternPathSupported = false
 )
 
-func (c patternPathSupportedConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	isPatternPathSupported = td.GoVersion.GreaterThanEqual(patternPathMinVersion)
+func (c patternPathSupportedConst) InjectOption(info *process.Info) (inject.Option, error) {
+	isPatternPathSupported = info.GoVersion.GreaterThanEqual(patternPathMinVersion)
 	return inject.WithKeyValue("pattern_path_supported", isPatternPathSupported), nil
 }
 
 type swissMapsUsedConst struct{}
 
-func (c swissMapsUsedConst) InjectOption(td *process.TargetDetails) (inject.Option, error) {
-	isUsingGoSwissMaps := td.GoVersion.GreaterThanEqual(goMapsVersion)
+func (c swissMapsUsedConst) InjectOption(info *process.Info) (inject.Option, error) {
+	isUsingGoSwissMaps := info.GoVersion.GreaterThanEqual(goMapsVersion)
 	return inject.WithKeyValue("swiss_maps_used", isUsingGoSwissMaps), nil
 }
 

--- a/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
+++ b/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
@@ -16,12 +16,12 @@ import (
 const bpfFsPath = "/sys/fs/bpf"
 
 // PathForTargetApplication returns the path to the BPF file-system for the given target.
-func PathForTargetApplication(target *process.TargetDetails) string {
+func PathForTargetApplication(target *process.Info) string {
 	return fmt.Sprintf("%s/%d", bpfFsPath, target.PID)
 }
 
 // Mount mounts the BPF file-system for the given target.
-func Mount(target *process.TargetDetails) error {
+func Mount(target *process.Info) error {
 	if !isBPFFSMounted() {
 		// Directory does not exist, create it and mount
 		if err := os.MkdirAll(bpfFsPath, 0o755); err != nil {
@@ -49,6 +49,6 @@ func isBPFFSMounted() bool {
 }
 
 // Cleanup removes the BPF file-system for the given target.
-func Cleanup(target *process.TargetDetails) error {
+func Cleanup(target *process.Info) error {
 	return os.RemoveAll(PathForTargetApplication(target))
 }

--- a/internal/pkg/process/analyze.go
+++ b/internal/pkg/process/analyze.go
@@ -16,8 +16,8 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/process/binary"
 )
 
-// TargetDetails are the details about a target function.
-type TargetDetails struct {
+// Info are the details about a target process.
+type Info struct {
 	PID               int
 	Functions         []*binary.Func
 	GoVersion         *semver.Version
@@ -26,8 +26,8 @@ type TargetDetails struct {
 }
 
 // GetFunctionOffset returns the offset for of the function with name.
-func (t *TargetDetails) GetFunctionOffset(name string) (uint64, error) {
-	for _, f := range t.Functions {
+func (i *Info) GetFunctionOffset(name string) (uint64, error) {
+	for _, f := range i.Functions {
 		if f.Name == name {
 			return f.Offset, nil
 		}
@@ -38,8 +38,8 @@ func (t *TargetDetails) GetFunctionOffset(name string) (uint64, error) {
 
 // GetFunctionReturns returns the return value of the call for the function
 // with name.
-func (t *TargetDetails) GetFunctionReturns(name string) ([]uint64, error) {
-	for _, f := range t.Functions {
+func (i *Info) GetFunctionReturns(name string) ([]uint64, error) {
+	for _, f := range i.Functions {
 		if f.Name == name {
 			return f.ReturnOffsets, nil
 		}
@@ -49,14 +49,14 @@ func (t *TargetDetails) GetFunctionReturns(name string) ([]uint64, error) {
 }
 
 // OpenExe opens the executable of the target process for reading.
-func (t *TargetDetails) OpenExe() (*os.File, error) {
-	path := fmt.Sprintf("/proc/%d/exe", t.PID)
+func (i *Info) OpenExe() (*os.File, error) {
+	path := fmt.Sprintf("/proc/%d/exe", i.PID)
 	return os.Open(path)
 }
 
 // Analyze returns the target details for an actively running process.
-func (a *Analyzer) Analyze(pid int, relevantFuncs map[string]interface{}) (*TargetDetails, error) {
-	result := &TargetDetails{PID: pid}
+func (a *Analyzer) Analyze(pid int, relevantFuncs map[string]interface{}) (*Info, error) {
+	result := &Info{PID: pid}
 
 	f, err := result.OpenExe()
 	if err != nil {


### PR DESCRIPTION
Utilizing the package name, concisely name the type to better reflect what it represents.