### PR TITLE
Rename process.AllocationDetails to process.Allocation

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -101,11 +101,11 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 		return nil, err
 	}
 
-	allocDetails, err := process.Allocate(c.logger, pid)
+	alloc, err := process.Allocate(c.logger, pid)
 	if err != nil {
 		return nil, err
 	}
-	td.AllocationDetails = allocDetails
+	td.Allocation = alloc
 
 	c.logger.Info(
 		"target process analysis completed",

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -107,13 +107,13 @@ func (o errOpt) apply(map[string]interface{}) error {
 	return o.err
 }
 
-// WithAllocationDetails returns an option that will set "total_cpus",
-// "start_addr", and "end_addr".
-func WithAllocationDetails(details process.AllocationDetails) Option {
+// WithAllocation returns an option that will set "total_cpus", "start_addr",
+// and "end_addr".
+func WithAllocation(alloc process.Allocation) Option {
 	return option{
-		keyTotalCPUs: details.NumCPU,
-		keyStartAddr: details.StartAddr,
-		keyEndAddr:   details.EndAddr,
+		keyTotalCPUs: alloc.NumCPU,
+		keyStartAddr: alloc.StartAddr,
+		keyEndAddr:   alloc.EndAddr,
 	}
 }
 

--- a/internal/pkg/inject/consts_test.go
+++ b/internal/pkg/inject/consts_test.go
@@ -16,13 +16,13 @@ import (
 
 func TestWithAllocationDetails(t *testing.T) {
 	const start, end, nCPU uint64 = 1, 2, 3
-	details := process.AllocationDetails{
+	alloc := process.Allocation{
 		StartAddr: start,
 		EndAddr:   end,
 		NumCPU:    nCPU,
 	}
 
-	opts := []Option{WithAllocationDetails(details)}
+	opts := []Option{WithAllocation(alloc)}
 	got, err := newConsts(opts)
 	require.NoError(t, err)
 	require.Contains(t, got, keyTotalCPUs)

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -385,8 +385,8 @@ func (m *Manager) loadProbes(target *process.Info) error {
 }
 
 func (m *Manager) mount(target *process.Info) error {
-	if target.AllocationDetails != nil {
-		m.logger.Debug("Mounting bpffs", "allocations_details", target.AllocationDetails)
+	if target.Allocation != nil {
+		m.logger.Debug("Mounting bpffs", "allocation", target.Allocation)
 	} else {
 		m.logger.Debug("Mounting bpffs")
 	}

--- a/internal/pkg/instrumentation/manager_test.go
+++ b/internal/pkg/instrumentation/manager_test.go
@@ -36,11 +36,10 @@ func TestProbeFiltering(t *testing.T) {
 		m := fakeManager(t)
 
 		info := process.Info{
-			PID:               1,
-			Functions:         []*binary.Func{},
-			GoVersion:         ver,
-			Modules:           map[string]*semver.Version{},
-			AllocationDetails: nil,
+			PID:       1,
+			Functions: []*binary.Func{},
+			GoVersion: ver,
+			Modules:   map[string]*semver.Version{},
 		}
 		m.FilterUnusedProbes(&info)
 		assert.Empty(t, m.probes)
@@ -54,11 +53,10 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:               1,
-			Functions:         httpFuncs,
-			GoVersion:         ver,
-			Modules:           map[string]*semver.Version{},
-			AllocationDetails: nil,
+			PID:       1,
+			Functions: httpFuncs,
+			GoVersion: ver,
+			Modules:   map[string]*semver.Version{},
 		}
 		m.FilterUnusedProbes(&info)
 		assert.Len(t, m.probes, 1) // one function, single probe
@@ -73,11 +71,10 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:               1,
-			Functions:         httpFuncs,
-			GoVersion:         ver,
-			Modules:           map[string]*semver.Version{},
-			AllocationDetails: nil,
+			PID:       1,
+			Functions: httpFuncs,
+			GoVersion: ver,
+			Modules:   map[string]*semver.Version{},
 		}
 		m.FilterUnusedProbes(&info)
 		assert.Len(t, m.probes, 2)
@@ -93,11 +90,10 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:               1,
-			Functions:         httpFuncs,
-			GoVersion:         ver,
-			Modules:           map[string]*semver.Version{},
-			AllocationDetails: nil,
+			PID:       1,
+			Functions: httpFuncs,
+			GoVersion: ver,
+			Modules:   map[string]*semver.Version{},
 		}
 		m.FilterUnusedProbes(&info)
 		assert.Len(t, m.probes, 1)

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -575,13 +575,13 @@ func (c StructFieldConstMinVersion) InjectOption(info *process.Info) (inject.Opt
 type AllocationConst struct{}
 
 // InjectOption returns the appropriately configured
-// [inject.WithAllocationDetails] if the [process.AllocationDetails] within td
-// are not nil. An error is returned if [process.AllocationDetails] is nil.
+// [inject.WithAllocation] if the [process.Allocation] within td
+// are not nil. An error is returned if [process.Allocation] is nil.
 func (c AllocationConst) InjectOption(info *process.Info) (inject.Option, error) {
-	if info.AllocationDetails == nil {
+	if info.Allocation == nil {
 		return nil, errors.New("no allocation details")
 	}
-	return inject.WithAllocationDetails(*info.AllocationDetails), nil
+	return inject.WithAllocation(*info.Allocation), nil
 }
 
 // KeyValConst is a [Const] for a generic key-value pair.

--- a/internal/pkg/instrumentation/testutils/testutils.go
+++ b/internal/pkg/instrumentation/testutils/testutils.go
@@ -32,7 +32,7 @@ func ProbesLoad(t *testing.T, p TestProbe, libs map[string]*semver.Version) {
 
 	info := &process.Info{
 		PID: 1,
-		AllocationDetails: &process.AllocationDetails{
+		Allocation: &process.Allocation{
 			StartAddr: 140434497441792,
 			EndAddr:   140434497507328,
 		},

--- a/internal/pkg/process/allocate.go
+++ b/internal/pkg/process/allocate.go
@@ -14,15 +14,15 @@ import (
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"
 )
 
-// AllocationDetails are the details about allocated memory.
-type AllocationDetails struct {
+// Allocation represent memory that has been allocated for a process.
+type Allocation struct {
 	StartAddr uint64
 	EndAddr   uint64
 	NumCPU    uint64
 }
 
 // Allocate allocates memory for the instrumented process.
-func Allocate(logger *slog.Logger, pid int) (*AllocationDetails, error) {
+func Allocate(logger *slog.Logger, pid int) (*Allocation, error) {
 	// runtime.NumCPU doesn't query any kind of hardware or OS state,
 	// but merely uses affinity APIs to count what CPUs the given go process is available to run on.
 	// Go's implementation of runtime.NumCPU (https://github.com/golang/go/blob/48d899dcdbed4534ed942f7ec2917cf86b18af22/src/runtime/os_linux.go#L97)
@@ -57,7 +57,7 @@ func Allocate(logger *slog.Logger, pid int) (*AllocationDetails, error) {
 		"end_addr", fmt.Sprintf("0x%x", addr+mapSize),
 	)
 
-	return &AllocationDetails{
+	return &Allocation{
 		StartAddr: addr,
 		EndAddr:   addr + mapSize,
 		NumCPU:    nCPU,

--- a/internal/pkg/process/analyze.go
+++ b/internal/pkg/process/analyze.go
@@ -18,11 +18,11 @@ import (
 
 // Info are the details about a target process.
 type Info struct {
-	PID               int
-	Functions         []*binary.Func
-	GoVersion         *semver.Version
-	Modules           map[string]*semver.Version
-	AllocationDetails *AllocationDetails
+	PID        int
+	Functions  []*binary.Func
+	GoVersion  *semver.Version
+	Modules    map[string]*semver.Version
+	Allocation *Allocation
 }
 
 // GetFunctionOffset returns the offset for of the function with name.


### PR DESCRIPTION
Shorten the type name to succinctly describe what it represents.