### PR TITLE
Add the `ID` type to the `process` package

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -239,7 +239,7 @@ func newInstConfig(ctx context.Context, opts []InstrumentationOption) (instConfi
 
 func (c instConfig) defaultServiceName() string {
 	name := "unknown_service"
-	if exe, err := c.pid.ExePath(); err == nil {
+	if exe, err := c.pid.ExeLink(); err == nil {
 		name = fmt.Sprintf("%s:%s", name, filepath.Base(exe))
 	}
 	return name

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -5,7 +5,6 @@ package auto
 
 import (
 	"context"
-	"debug/buildinfo"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel/attribute"
@@ -78,13 +76,7 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 		return nil, err
 	}
 
-	pa := process.NewAnalyzer(c.logger)
-	err = pa.SetBuildInfo(c.targetPID)
-	if err != nil {
-		return nil, err
-	}
-
-	ctrl, err := opentelemetry.NewController(c.logger, c.tracerProvider(pa.BuildInfo))
+	ctrl, err := opentelemetry.NewController(c.logger, c.tracerProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -110,12 +102,13 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 		return nil, err
 	}
 
-	td, err := pa.Analyze(c.targetPID, mngr.GetRelevantFuncs())
+	pa := process.NewAnalyzer(c.logger, c.pid)
+	td, err := pa.Analyze(mngr.GetRelevantFuncs())
 	if err != nil {
 		return nil, err
 	}
 
-	alloc, err := process.Allocate(c.logger, c.targetPID)
+	alloc, err := process.Allocate(c.logger, c.pid)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +191,7 @@ type InstrumentationOption interface {
 
 type instConfig struct {
 	traceExp           trace.SpanExporter
-	targetPID          int
+	pid                process.ID
 	serviceName        string
 	additionalResAttrs []attribute.KeyValue
 	globalImpl         bool
@@ -208,7 +201,7 @@ type instConfig struct {
 }
 
 func newInstConfig(ctx context.Context, opts []InstrumentationOption) (instConfig, error) {
-	c := instConfig{targetPID: -1}
+	c := instConfig{pid: -1}
 	var err error
 	for _, opt := range opts {
 		if opt != nil {
@@ -246,48 +239,60 @@ func newInstConfig(ctx context.Context, opts []InstrumentationOption) (instConfi
 
 func (c instConfig) defaultServiceName() string {
 	name := "unknown_service"
-	if exe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", c.targetPID)); err == nil {
+	if exe, err := c.pid.ExePath(); err == nil {
 		name = fmt.Sprintf("%s:%s", name, filepath.Base(exe))
 	}
 	return name
 }
 
 func (c instConfig) validate() error {
-	if c.targetPID <= 0 {
-		return errors.New("target PID not provided")
+	var err error
+	if e := c.pid.Validate(); e != nil {
+		err = errors.Join(err, e)
 	}
-	p, err := os.FindProcess(c.targetPID)
-	if err != nil {
-		return fmt.Errorf("invalid PID: no process was found with PID %d: %w", c.targetPID, err)
-	}
-	err = p.Signal(syscall.Signal(0))
-	if err != nil {
-		return fmt.Errorf("non-existent PID: %d: %w", c.targetPID, err)
-	}
-
 	if c.traceExp == nil {
-		return errors.New("undefined trace exporter")
+		err = errors.Join(err, errors.New("undefined trace exporter"))
 	}
-
-	return nil
+	return err
 }
 
-func (c instConfig) tracerProvider(bi *buildinfo.BuildInfo) *trace.TracerProvider {
+func (c instConfig) tracerProvider() *trace.TracerProvider {
 	return trace.NewTracerProvider(
 		// the actual sampling is done in the eBPF probes.
 		// this is just to make sure that we export all spans we get from the probes
 		trace.WithSampler(trace.AlwaysSample()),
-		trace.WithResource(c.res(bi)),
+		trace.WithResource(c.res()),
 		trace.WithBatcher(c.traceExp),
 		trace.WithIDGenerator(opentelemetry.NewEBPFSourceIDGenerator()),
 	)
 }
 
-func (c instConfig) res(bi *buildinfo.BuildInfo) *resource.Resource {
-	runVer := bi.GoVersion
+func (c instConfig) res() (res *resource.Resource) {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceNameKey.String(c.serviceName),
+		semconv.TelemetrySDKLanguageGo,
+		semconv.TelemetryDistroVersionKey.String(Version()),
+		semconv.TelemetryDistroNameKey.String("opentelemetry-go-instrumentation"),
+	}
+
+	defer func() {
+		if len(c.additionalResAttrs) > 0 {
+			attrs = append(attrs, c.additionalResAttrs...)
+		}
+
+		res = resource.NewWithAttributes(
+			semconv.SchemaURL,
+			attrs...,
+		)
+	}()
+
+	bi, err := c.pid.BuildInfo()
+	if err != nil {
+		c.logger.Error("omitting Go process info from resource", "error", err)
+		return
+	}
 
 	var compiler string
-
 	for _, setting := range bi.Settings {
 		if setting.Key == "-compiler" {
 			compiler = setting.Value
@@ -301,27 +306,17 @@ func (c instConfig) res(bi *buildinfo.BuildInfo) *resource.Resource {
 	}
 	runDesc := fmt.Sprintf(
 		"go version %s %s/%s",
-		runVer, runtime.GOOS, runtime.GOARCH,
+		bi.GoVersion, runtime.GOOS, runtime.GOARCH,
 	)
 
-	attrs := []attribute.KeyValue{
-		semconv.ServiceNameKey.String(c.serviceName),
-		semconv.TelemetrySDKLanguageGo,
-		semconv.TelemetryDistroVersionKey.String(Version()),
-		semconv.TelemetryDistroNameKey.String("opentelemetry-go-instrumentation"),
+	attrs = append(
+		attrs,
 		semconv.ProcessRuntimeName(runName),
-		semconv.ProcessRuntimeVersion(runVer),
+		semconv.ProcessRuntimeVersion(bi.GoVersion),
 		semconv.ProcessRuntimeDescription(runDesc),
-	}
-
-	if len(c.additionalResAttrs) > 0 {
-		attrs = append(attrs, c.additionalResAttrs...)
-	}
-
-	return resource.NewWithAttributes(
-		semconv.SchemaURL,
-		attrs...,
 	)
+
+	return res
 }
 
 // newLogger is used for testing.
@@ -359,7 +354,7 @@ func WithServiceName(serviceName string) InstrumentationOption {
 // one will be used.
 func WithPID(pid int) InstrumentationOption {
 	return fnOpt(func(_ context.Context, c instConfig) (instConfig, error) {
-		c.targetPID = pid
+		c.pid = process.ID(pid)
 		return c, nil
 	})
 }

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -103,7 +103,7 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 	}
 
 	pa := process.NewAnalyzer(c.logger, c.pid)
-	td, err := pa.Analyze(mngr.GetRelevantFuncs())
+	pi, err := pa.Analyze(mngr.GetRelevantFuncs())
 	if err != nil {
 		return nil, err
 	}
@@ -112,19 +112,19 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 	if err != nil {
 		return nil, err
 	}
-	td.Allocation = alloc
+	pi.Allocation = alloc
 
 	c.logger.Info(
 		"target process analysis completed",
-		"pid", td.ID,
-		"go_version", td.GoVersion,
-		"dependencies", td.Modules,
-		"total_functions_found", len(td.Functions),
+		"pid", pi.ID,
+		"go_version", pi.GoVersion,
+		"dependencies", pi.Modules,
+		"total_functions_found", len(pi.Functions),
 	)
-	mngr.FilterUnusedProbes(td)
+	mngr.FilterUnusedProbes(pi)
 
 	return &Instrumentation{
-		target:   td,
+		target:   pi,
 		analyzer: pa,
 		manager:  mngr,
 	}, nil

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -116,7 +116,7 @@ func NewInstrumentation(ctx context.Context, opts ...InstrumentationOption) (*In
 
 	c.logger.Info(
 		"target process analysis completed",
-		"pid", td.PID,
+		"pid", td.ID,
 		"go_version", td.GoVersion,
 		"dependencies", td.Modules,
 		"total_functions_found", len(td.Functions),

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -22,6 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe/sampling"
+	"go.opentelemetry.io/auto/internal/pkg/process"
 )
 
 func TestWithServiceName(t *testing.T) {
@@ -42,7 +43,7 @@ func TestWithServiceName(t *testing.T) {
 func TestWithPID(t *testing.T) {
 	c, err := newInstConfig(context.Background(), []InstrumentationOption{WithPID(1)})
 	require.NoError(t, err)
-	assert.Equal(t, 1, c.targetPID)
+	assert.Equal(t, process.ID(1), c.pid)
 }
 
 func TestWithEnv(t *testing.T) {

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -149,16 +149,16 @@ func WithOffset(key string, id structfield.ID, ver *semver.Version) Option {
 }
 
 func FindOffset(id structfield.ID, info *process.Info) (structfield.OffsetKey, error) {
-	fd, err := info.OpenExe()
+	path, err := process.ID(info.PID).ExePath()
 	if err != nil {
 		return structfield.OffsetKey{}, err
 	}
-	defer fd.Close()
 
-	elfF, err := elf.NewFile(fd)
+	elfF, err := elf.Open(path)
 	if err != nil {
 		return structfield.OffsetKey{}, err
 	}
+	defer elfF.Close()
 
 	data, err := elfF.DWARF()
 	if err != nil {

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -149,7 +149,7 @@ func WithOffset(key string, id structfield.ID, ver *semver.Version) Option {
 }
 
 func FindOffset(id structfield.ID, info *process.Info) (structfield.OffsetKey, error) {
-	elfF, err := elf.Open(process.ID(info.PID).ExePath())
+	elfF, err := elf.Open(info.ID.ExePath())
 	if err != nil {
 		return structfield.OffsetKey{}, err
 	}

--- a/internal/pkg/inject/consts.go
+++ b/internal/pkg/inject/consts.go
@@ -149,12 +149,7 @@ func WithOffset(key string, id structfield.ID, ver *semver.Version) Option {
 }
 
 func FindOffset(id structfield.ID, info *process.Info) (structfield.OffsetKey, error) {
-	path, err := process.ID(info.PID).ExePath()
-	if err != nil {
-		return structfield.OffsetKey{}, err
-	}
-
-	elfF, err := elf.Open(path)
+	elfF, err := elf.Open(process.ID(info.PID).ExePath())
 	if err != nil {
 		return structfield.OffsetKey{}, err
 	}

--- a/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
+++ b/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
@@ -17,7 +17,7 @@ const bpfFsPath = "/sys/fs/bpf"
 
 // PathForTargetApplication returns the path to the BPF file-system for the given target.
 func PathForTargetApplication(target *process.Info) string {
-	return fmt.Sprintf("%s/%d", bpfFsPath, target.PID)
+	return fmt.Sprintf("%s/%d", bpfFsPath, target.ID)
 }
 
 // Mount mounts the BPF file-system for the given target.

--- a/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
+++ b/internal/pkg/instrumentation/bpffs/bpfsfs_linux.go
@@ -16,8 +16,8 @@ import (
 const bpfFsPath = "/sys/fs/bpf"
 
 // PathForTargetApplication returns the path to the BPF file-system for the given target.
-func PathForTargetApplication(target *process.Info) string {
-	return fmt.Sprintf("%s/%d", bpfFsPath, target.ID)
+func PathForTargetApplication(pi *process.Info) string {
+	return fmt.Sprintf("%s/%d", bpfFsPath, pi.ID)
 }
 
 // Mount mounts the BPF file-system for the given target.

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -23,7 +23,13 @@ import (
 
 // Function variables overridden in testing.
 var (
-	openExecutable      = link.OpenExecutable
+	openExecutable = func(id int) (*link.Executable, error) {
+		path, err := process.ID(id).ExePath()
+		if err != nil {
+			return nil, err
+		}
+		return link.OpenExecutable(path)
+	}
 	rlimitRemoveMemlock = rlimit.RemoveMemlock
 	bpffsMount          = bpffs.Mount
 	bpffsCleanup        = bpffs.Cleanup
@@ -345,7 +351,7 @@ func (m *Manager) loadProbes(target *process.Info) error {
 		return err
 	}
 
-	exe, err := openExecutable(fmt.Sprintf("/proc/%d/exe", target.PID))
+	exe, err := openExecutable(target.PID)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -23,13 +23,7 @@ import (
 
 // Function variables overridden in testing.
 var (
-	openExecutable = func(id int) (*link.Executable, error) {
-		path, err := process.ID(id).ExePath()
-		if err != nil {
-			return nil, err
-		}
-		return link.OpenExecutable(path)
-	}
+	openExecutable      = link.OpenExecutable
 	rlimitRemoveMemlock = rlimit.RemoveMemlock
 	bpffsMount          = bpffs.Mount
 	bpffsCleanup        = bpffs.Cleanup
@@ -351,7 +345,7 @@ func (m *Manager) loadProbes(target *process.Info) error {
 		return err
 	}
 
-	exe, err := openExecutable(target.PID)
+	exe, err := openExecutable(process.ID(target.PID).ExePath())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -345,7 +345,7 @@ func (m *Manager) loadProbes(target *process.Info) error {
 		return err
 	}
 
-	exe, err := openExecutable(process.ID(target.PID).ExePath())
+	exe, err := openExecutable(target.ID.ExePath())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/instrumentation/manager_test.go
+++ b/internal/pkg/instrumentation/manager_test.go
@@ -214,7 +214,7 @@ func fakeManager(t *testing.T) *Manager {
 
 func mockExeAndBpffs(t *testing.T) {
 	origOpenExecutable := openExecutable
-	openExecutable = func(int) (*link.Executable, error) { return &link.Executable{}, nil }
+	openExecutable = func(string) (*link.Executable, error) { return &link.Executable{}, nil }
 	t.Cleanup(func() { openExecutable = origOpenExecutable })
 
 	origRlimitRemoveMemlock := rlimitRemoveMemlock

--- a/internal/pkg/instrumentation/manager_test.go
+++ b/internal/pkg/instrumentation/manager_test.go
@@ -45,7 +45,7 @@ func TestProbeFiltering(t *testing.T) {
 		m := fakeManager(t)
 
 		info := process.Info{
-			PID:       1,
+			ID:        1,
 			Functions: []*binary.Func{},
 			GoVersion: ver,
 			Modules:   map[string]*semver.Version{},
@@ -62,7 +62,7 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:       1,
+			ID:        1,
 			Functions: httpFuncs,
 			GoVersion: ver,
 			Modules:   map[string]*semver.Version{},
@@ -80,7 +80,7 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:       1,
+			ID:        1,
 			Functions: httpFuncs,
 			GoVersion: ver,
 			Modules:   map[string]*semver.Version{},
@@ -99,7 +99,7 @@ func TestProbeFiltering(t *testing.T) {
 		}
 
 		info := process.Info{
-			PID:       1,
+			ID:        1,
 			Functions: httpFuncs,
 			GoVersion: ver,
 			Modules:   map[string]*semver.Version{},
@@ -271,7 +271,7 @@ func TestRunStoppingByContext(t *testing.T) {
 	ctx, stopCtx := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 
-	err = m.Load(ctx, &process.Info{PID: 1000})
+	err = m.Load(ctx, &process.Info{ID: 1000})
 	require.NoError(t, err)
 
 	go func() { errCh <- m.Run(ctx) }()
@@ -320,7 +320,7 @@ func TestRunStoppingByStop(t *testing.T) {
 	ctx := context.Background()
 	errCh := make(chan error, 1)
 
-	err = m.Load(ctx, &process.Info{PID: 1000})
+	err = m.Load(ctx, &process.Info{ID: 1000})
 	require.NoError(t, err)
 
 	time.AfterFunc(100*time.Millisecond, func() {
@@ -450,7 +450,7 @@ func TestConfigProvider(t *testing.T) {
 	mockExeAndBpffs(t)
 	runCtx, cancel := context.WithCancel(context.Background())
 
-	err := m.Load(runCtx, &process.Info{PID: 1000})
+	err := m.Load(runCtx, &process.Info{ID: 1000})
 	require.NoError(t, err)
 
 	runErr := make(chan error, 1)
@@ -584,7 +584,7 @@ func TestRunStopDeadlock(t *testing.T) {
 	ctx, stopCtx := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 
-	err = m.Load(ctx, &process.Info{PID: 1000})
+	err = m.Load(ctx, &process.Info{ID: 1000})
 	require.NoError(t, err)
 
 	go func() { errCh <- m.Run(ctx) }()
@@ -649,7 +649,7 @@ func TestStopBeforeRun(t *testing.T) {
 
 	mockExeAndBpffs(t)
 
-	err = m.Load(context.Background(), &process.Info{PID: 1000})
+	err = m.Load(context.Background(), &process.Info{ID: 1000})
 	require.NoError(t, err)
 	require.True(t, p.loaded.Load())
 

--- a/internal/pkg/instrumentation/manager_test.go
+++ b/internal/pkg/instrumentation/manager_test.go
@@ -214,7 +214,7 @@ func fakeManager(t *testing.T) *Manager {
 
 func mockExeAndBpffs(t *testing.T) {
 	origOpenExecutable := openExecutable
-	openExecutable = func(string) (*link.Executable, error) { return &link.Executable{}, nil }
+	openExecutable = func(int) (*link.Executable, error) { return &link.Executable{}, nil }
 	t.Cleanup(func() { openExecutable = origOpenExecutable })
 
 	origRlimitRemoveMemlock := rlimitRemoveMemlock

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -396,7 +396,7 @@ func (u *Uprobe) load(exec *link.Executable, info *process.Info, c *ebpf.Collect
 		if !ok {
 			return fmt.Errorf("entry probe %s not found", u.EntryProbe)
 		}
-		opts := &link.UprobeOptions{Address: offset, PID: info.PID}
+		opts := &link.UprobeOptions{Address: offset, PID: int(info.ID)}
 		l, err := exec.Uprobe("", entryProg, opts)
 		if err != nil {
 			return err
@@ -415,7 +415,7 @@ func (u *Uprobe) load(exec *link.Executable, info *process.Info, c *ebpf.Collect
 		}
 
 		for _, ret := range retOffsets {
-			opts := &link.UprobeOptions{Address: ret, PID: info.PID}
+			opts := &link.UprobeOptions{Address: ret, PID: int(info.ID)}
 			l, err := exec.Uprobe("", retProg, opts)
 			if err != nil {
 				return err

--- a/internal/pkg/instrumentation/testutils/testutils.go
+++ b/internal/pkg/instrumentation/testutils/testutils.go
@@ -31,7 +31,7 @@ func ProbesLoad(t *testing.T, p TestProbe, libs map[string]*semver.Version) {
 	}
 
 	info := &process.Info{
-		PID: 1,
+		ID: 1,
 		Allocation: &process.Allocation{
 			StartAddr: 140434497441792,
 			EndAddr:   140434497507328,

--- a/internal/pkg/process/analyze.go
+++ b/internal/pkg/process/analyze.go
@@ -15,7 +15,7 @@ import (
 
 // Info are the details about a target process.
 type Info struct {
-	PID        int
+	ID         ID
 	Functions  []*binary.Func
 	GoVersion  *semver.Version
 	Modules    map[string]*semver.Version
@@ -47,7 +47,7 @@ func (i *Info) GetFunctionReturns(name string) ([]uint64, error) {
 
 // Analyze returns the target details for an actively running process.
 func (a *Analyzer) Analyze(relevantFuncs map[string]interface{}) (*Info, error) {
-	result := &Info{PID: int(a.id)}
+	result := &Info{ID: a.id}
 
 	elfF, err := elf.Open(a.id.ExePath())
 	if err != nil {

--- a/internal/pkg/process/discover.go
+++ b/internal/pkg/process/discover.go
@@ -4,17 +4,16 @@
 package process
 
 import (
-	"debug/buildinfo"
 	"log/slog"
 )
 
 // Analyzer is used to find actively running processes.
 type Analyzer struct {
-	logger    *slog.Logger
-	BuildInfo *buildinfo.BuildInfo
+	id     ID
+	logger *slog.Logger
 }
 
 // NewAnalyzer returns a new [ProcessAnalyzer].
-func NewAnalyzer(logger *slog.Logger) *Analyzer {
-	return &Analyzer{logger: logger}
+func NewAnalyzer(logger *slog.Logger, id ID) *Analyzer {
+	return &Analyzer{id: id, logger: logger}
 }

--- a/internal/pkg/process/id.go
+++ b/internal/pkg/process/id.go
@@ -56,16 +56,16 @@ var procDir = procDirFn
 
 func procDirFn(id ID) string { return "/proc/" + strconv.Itoa(int(id)) }
 
-// exePath returns the file path for executable link of the process ID.
-func (id ID) exePath() string { return id.dir() + "/exe" }
+// ExePath returns the file path for the executable link of the process ID.
+func (id ID) ExePath() string { return id.dir() + "/exe" }
 
 // taskPath returns the file path for the tasks directory of the process ID.
 func (id ID) taskPath() string { return id.dir() + "/task" }
 
-// ExePath returns the resolved absolute path to the executable being run by
-// the process.
-func (id ID) ExePath() (string, error) {
-	p, err := os.Readlink(id.exePath())
+// ExeLink returns the resolved absolute path to the linked executable being
+// run by the process.
+func (id ID) ExeLink() (string, error) {
+	p, err := os.Readlink(id.ExePath())
 	if err != nil {
 		return "", err
 	}
@@ -83,11 +83,7 @@ func (id ID) Tasks() ([]fs.DirEntry, error) {
 
 // BuildInfo returns the Go build info of the process ID executable.
 func (id ID) BuildInfo() (*buildinfo.BuildInfo, error) {
-	path, err := id.ExePath()
-	if err != nil {
-		return nil, err
-	}
-	bi, err := buildinfoReadFile(path)
+	bi, err := buildinfoReadFile(id.ExePath())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/process/id.go
+++ b/internal/pkg/process/id.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package process
+
+import (
+	"debug/buildinfo"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ID represents a process identification number.
+type ID int
+
+// Validate returns nil if id represents a valid running process. Otherwise, an
+// error is returned.
+func (id ID) Validate() error {
+	if id < 0 {
+		return fmt.Errorf("invalid ID: %d", id)
+	}
+
+	p, err := os.FindProcess(int(id))
+	if err != nil {
+		return fmt.Errorf("no process with ID %d found: %w", id, err)
+	}
+
+	err = p.Signal(syscall.Signal(0))
+	if err != nil {
+		return fmt.Errorf("no process with ID %d found running: %w", id, err)
+	}
+	return nil
+}
+
+func (id ID) dir() string {
+	return "/proc/" + strconv.Itoa(int(id))
+}
+
+// exePath returns the file path for executable link of the process ID.
+func (id ID) exePath() string {
+	return id.dir() + "/exe"
+}
+
+// taskPath returns the file path for the tasks directory of the process ID.
+func (id ID) taskPath() string {
+	return id.dir() + "/task"
+}
+
+// ExePath returns the resolved absolute path to the executable being run by
+// the process.
+func (id ID) ExePath() (string, error) {
+	p, err := os.Readlink(id.exePath())
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(p) {
+		return p, nil
+	}
+
+	return filepath.Abs(filepath.Join(id.dir(), p))
+}
+
+// Tasks returns the task directory contents for the process.
+func (id ID) Tasks() ([]fs.DirEntry, error) {
+	return os.ReadDir(id.taskPath())
+}
+
+// BuildInfo returns the Go build info of the process ID executable.
+func (id ID) BuildInfo() (*buildinfo.BuildInfo, error) {
+	path, err := id.ExePath()
+	if err != nil {
+		return nil, err
+	}
+	bi, err := buildinfo.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	bi.GoVersion = strings.ReplaceAll(bi.GoVersion, "go", "")
+	// Trims GOEXPERIMENT version suffix if present.
+	if idx := strings.Index(bi.GoVersion, " X:"); idx > 0 {
+		bi.GoVersion = bi.GoVersion[:idx]
+	}
+
+	return bi, nil
+}

--- a/internal/pkg/process/id_test.go
+++ b/internal/pkg/process/id_test.go
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package process
+
+import (
+	"debug/buildinfo"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setup sets up a temporary testing process directory:
+//
+//	{temp}/
+//	{temp}/app
+//	{temp}/{pid}
+//	{temp}/task/
+//	{temp}/task/{task_0 ...}
+//
+// The testing app file handle is returned.
+//
+// All created files and directories are cleaned up on test exit.
+func setup(t *testing.T, pid ID, tasks ...string) *os.File {
+	t.Helper()
+
+	// Override procDir for testing.
+	orig := procDir
+	t.Cleanup(func() { procDir = orig })
+
+	tmpDir := t.TempDir()
+	t.Logf("temp dir: %s", tmpDir)
+	procDir = func(id ID) string {
+		return filepath.Join(tmpDir, strconv.Itoa(int(id)))
+	}
+
+	// Add a proc entry for pid.
+	require.NoError(t, os.MkdirAll(procDir(pid), 0o755))
+
+	// Create directories for any tasks.
+	taskPath := filepath.Join(procDir(pid), "task")
+	for _, task := range tasks {
+		path := filepath.Join(taskPath, task)
+		require.NoError(t, os.MkdirAll(path, 0o755))
+	}
+
+	// Create the app. Do not link, leave that for the tests.
+	app, err := os.Create(filepath.Join(tmpDir, "app"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = app.Close() })
+
+	// Used for debugging test failures (is not prited on success).
+	_ = filepath.Walk(tmpDir, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		t.Log(path)
+		return nil
+	})
+
+	return app
+}
+
+func TestIDValidate(t *testing.T) {
+	t.Run("InvalidID", func(t *testing.T) {
+		err := ID(-1).Validate()
+		assert.ErrorIs(t, err, errInvalidID)
+	})
+
+	t.Run("NoProcess", func(t *testing.T) {
+		orig := osFindProcess
+		t.Cleanup(func() { osFindProcess = orig })
+		osFindProcess = func(int) (*os.Process, error) {
+			return nil, assert.AnError
+		}
+
+		err := ID(1).Validate()
+		assert.ErrorIs(t, err, errNoID)
+		assert.ErrorIs(t, err, assert.AnError, "original error dropped")
+	})
+
+	t.Run("NoRunningProcess", func(t *testing.T) {
+		t.Cleanup(func(orig func(int) (*os.Process, error)) func() {
+			p := new(os.Process)
+			osFindProcess = func(int) (*os.Process, error) { return p, nil }
+			return func() { osFindProcess = orig }
+		}(osFindProcess))
+
+		t.Cleanup(func(orig func(p *os.Process, s os.Signal) error) func() {
+			sig = func(p *os.Process, s os.Signal) error {
+				return assert.AnError
+			}
+			return func() { sig = orig }
+		}(sig))
+
+		err := ID(1).Validate()
+		assert.ErrorIs(t, err, errNoRunID)
+		assert.ErrorIs(t, err, assert.AnError, "original error dropped")
+	})
+
+	t.Run("NoError", func(t *testing.T) {
+		t.Cleanup(func(orig func(int) (*os.Process, error)) func() {
+			p := new(os.Process)
+			osFindProcess = func(int) (*os.Process, error) { return p, nil }
+			return func() { osFindProcess = orig }
+		}(osFindProcess))
+
+		t.Cleanup(func(orig func(p *os.Process, s os.Signal) error) func() {
+			sig = func(p *os.Process, s os.Signal) error { return nil }
+			return func() { sig = orig }
+		}(sig))
+
+		assert.NoError(t, ID(1).Validate())
+	})
+}
+
+func TestIDExePath(t *testing.T) {
+	const pid = 100
+	app := setup(t, pid)
+
+	ln := filepath.Join(procDir(pid), "exe")
+
+	t.Run("AbsolutePath", func(t *testing.T) {
+		require.NoError(t, os.Symlink(app.Name(), ln))
+		t.Cleanup(func() { require.NoError(t, os.Remove(ln)) })
+
+		got, err := ID(pid).ExePath()
+		require.NoError(t, err)
+		assert.Equal(t, app.Name(), got)
+	})
+
+	t.Run("RelativePath", func(t *testing.T) {
+		require.NoError(t, os.Symlink("../app", ln))
+		t.Cleanup(func() { require.NoError(t, os.Remove(ln)) })
+
+		got, err := ID(pid).ExePath()
+		require.NoError(t, err)
+		assert.Equal(t, app.Name(), got)
+	})
+}
+
+func TestIDTasks(t *testing.T) {
+	const pid = 100
+	dirs := []string{"1234", "4321"}
+	_ = setup(t, pid, dirs...)
+
+	entries, err := ID(pid).Tasks()
+	require.NoError(t, err)
+
+	var got []string
+	for _, e := range entries {
+		got = append(got, e.Name())
+	}
+	assert.Equal(t, dirs, got)
+}
+
+func TestIDBuildInfo(t *testing.T) {
+	const pid = 100
+	app := setup(t, pid)
+
+	ln := filepath.Join(procDir(pid), "exe")
+	require.NoError(t, os.Symlink(app.Name(), ln))
+
+	orig := buildinfoReadFile
+	t.Cleanup(func() { buildinfoReadFile = orig })
+
+	buildinfoReadFile = func(name string) (*buildinfo.BuildInfo, error) {
+		assert.Equal(t, app.Name(), name, "wrong exe path")
+		return &debug.BuildInfo{
+			Path:      app.Name(),
+			GoVersion: "go1.22.0 X:testing",
+		}, nil
+	}
+
+	got, err := ID(pid).BuildInfo()
+	require.NoError(t, err)
+
+	want := &debug.BuildInfo{Path: app.Name(), GoVersion: "1.22.0"}
+	assert.Equal(t, want, got)
+}

--- a/internal/pkg/process/id_test.go
+++ b/internal/pkg/process/id_test.go
@@ -119,7 +119,7 @@ func TestIDValidate(t *testing.T) {
 	})
 }
 
-func TestIDExePath(t *testing.T) {
+func TestIDExeLink(t *testing.T) {
 	const pid = 100
 	app := setup(t, pid)
 
@@ -129,7 +129,7 @@ func TestIDExePath(t *testing.T) {
 		require.NoError(t, os.Symlink(app.Name(), ln))
 		t.Cleanup(func() { require.NoError(t, os.Remove(ln)) })
 
-		got, err := ID(pid).ExePath()
+		got, err := ID(pid).ExeLink()
 		require.NoError(t, err)
 		assert.Equal(t, app.Name(), got)
 	})
@@ -138,7 +138,7 @@ func TestIDExePath(t *testing.T) {
 		require.NoError(t, os.Symlink("../app", ln))
 		t.Cleanup(func() { require.NoError(t, os.Remove(ln)) })
 
-		got, err := ID(pid).ExePath()
+		got, err := ID(pid).ExeLink()
 		require.NoError(t, err)
 		assert.Equal(t, app.Name(), got)
 	})
@@ -170,7 +170,7 @@ func TestIDBuildInfo(t *testing.T) {
 	t.Cleanup(func() { buildinfoReadFile = orig })
 
 	buildinfoReadFile = func(name string) (*buildinfo.BuildInfo, error) {
-		assert.Equal(t, app.Name(), name, "wrong exe path")
+		assert.Equal(t, ID(pid).ExePath(), name, "wrong exe path")
 		return &debug.BuildInfo{
 			Path:      app.Name(),
 			GoVersion: "go1.22.0 X:testing",

--- a/internal/pkg/process/ptrace_linux.go
+++ b/internal/pkg/process/ptrace_linux.go
@@ -6,7 +6,6 @@ package process
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -59,7 +58,7 @@ func waitPid(pid int) error {
 }
 
 // newTracedProgram ptrace all threads of a process.
-func newTracedProgram(pid int, logger *slog.Logger) (*tracedProgram, error) {
+func newTracedProgram(id ID, logger *slog.Logger) (*tracedProgram, error) {
 	tidMap := make(map[int]bool)
 	retryCount := make(map[int]int)
 
@@ -71,7 +70,7 @@ func newTracedProgram(pid int, logger *slog.Logger) (*tracedProgram, error) {
 	// ...
 	// only the first way finally worked for every situations
 	for {
-		threads, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+		threads, err := id.Tasks()
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -139,7 +138,7 @@ func newTracedProgram(pid int, logger *slog.Logger) (*tracedProgram, error) {
 	}
 
 	program := &tracedProgram{
-		pid:        pid,
+		pid:        int(id),
 		tids:       tids,
 		backupRegs: &syscall.PtraceRegs{},
 		backupCode: make([]byte, syscallInstrSize),

--- a/internal/pkg/process/ptrace_other.go
+++ b/internal/pkg/process/ptrace_other.go
@@ -11,7 +11,7 @@ import "log/slog"
 
 type tracedProgram struct{}
 
-func newTracedProgram(pid int, logger *slog.Logger) (*tracedProgram, error) {
+func newTracedProgram(pid ID, logger *slog.Logger) (*tracedProgram, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
We have many tasks throughout the code-base that interact with a process:

- Open the process executable link
- Validate the process exists and is running
- Open the process tasks
- Create a new `debug.BuildInfo` object for the program being run by the process

Encapsulate these interactions in the added `process.ID` type.

Planned follow up: integrate with the `process.Info` type.