### PR TITLE
Lazy allocate memory for process 

### DIFF
--- a/internal/pkg/instrumentation/manager.go
+++ b/internal/pkg/instrumentation/manager.go
@@ -80,12 +80,6 @@ func NewManager(logger *slog.Logger, otelController *opentelemetry.Controller, p
 		return nil, err
 	}
 
-	alloc, err := process.Allocate(logger, pid)
-	if err != nil {
-		return nil, err
-	}
-	m.proc.Allocation = alloc
-
 	m.logger.Info("loaded process info", "process", m.proc)
 
 	m.filterUnusedProbes()
@@ -360,7 +354,8 @@ func (m *Manager) loadProbes() error {
 	}
 	m.exe = exe
 
-	if err := m.mount(); err != nil {
+	m.logger.Debug("Mounting bpffs")
+	if err := bpffsMount(m.proc); err != nil {
 		return err
 	}
 
@@ -378,15 +373,6 @@ func (m *Manager) loadProbes() error {
 
 	m.logger.Debug("loaded probes to memory", "total_probes", len(m.probes))
 	return nil
-}
-
-func (m *Manager) mount() error {
-	if m.proc.Allocation != nil {
-		m.logger.Debug("Mounting bpffs", "allocation", m.proc.Allocation)
-	} else {
-		m.logger.Debug("Mounting bpffs")
-	}
-	return bpffsMount(m.proc)
 }
 
 func (m *Manager) cleanup() error {

--- a/internal/pkg/instrumentation/manager_load_test.go
+++ b/internal/pkg/instrumentation/manager_load_test.go
@@ -80,6 +80,13 @@ func TestLoadProbes(t *testing.T) {
 			ProbesLoad(t, info, p.(TestProbe))
 		})
 	}
+
+	// The grpcClient, grpcServer, httpClient, dbSql, kafkaProducer,
+	// kafkaConsumer, autosdk, and otelTraceGlobal all allocate. Ensure it has
+	// been called.
+	a, err := info.Alloc(logger)
+	require.NoError(t, err)
+	assert.NotEmpty(t, a.StartAddr, "memory not allocated")
 }
 
 const mainGoContent = `package main

--- a/internal/pkg/instrumentation/manager_load_test.go
+++ b/internal/pkg/instrumentation/manager_load_test.go
@@ -48,16 +48,11 @@ func TestLoadProbes(t *testing.T) {
 	// Reset Info module information.
 	info.Modules = make(map[string]*semver.Version)
 
-	logger := slog.Default()
-	info.Allocation, err = process.Allocate(logger, pid)
-	if err != nil {
-		t.Fatalf("failed to allocate for process %d: %v", id, err)
-	}
-
 	ver := utils.GetLinuxKernelVersion()
 	require.NotNil(t, ver)
 	t.Logf("Running on kernel %s", ver.String())
 
+	logger := slog.Default()
 	probes := []probe.Probe{
 		grpcClient.New(logger, ""),
 		grpcServer.New(logger, ""),

--- a/internal/pkg/process/allocate.go
+++ b/internal/pkg/process/allocate.go
@@ -21,8 +21,8 @@ type Allocation struct {
 	NumCPU    uint64
 }
 
-// Allocate allocates memory for the instrumented process.
-func Allocate(logger *slog.Logger, id ID) (*Allocation, error) {
+// allocate allocates memory for the instrumented process.
+func allocate(logger *slog.Logger, id ID) (*Allocation, error) {
 	// runtime.NumCPU doesn't query any kind of hardware or OS state,
 	// but merely uses affinity APIs to count what CPUs the given go process is available to run on.
 	// Go's implementation of runtime.NumCPU (https://github.com/golang/go/blob/48d899dcdbed4534ed942f7ec2917cf86b18af22/src/runtime/os_linux.go#L97)

--- a/internal/pkg/process/info.go
+++ b/internal/pkg/process/info.go
@@ -52,12 +52,15 @@ func (i *Info) Alloc(logger *slog.Logger) (*Allocation, error) {
 	return i.a, nil
 }
 
+// Used for testing.
+var allocateFn = allocate
+
 func (i *Info) alloc(logger *slog.Logger) (*Allocation, error) {
 	i.aMu.Lock()
 	defer i.aMu.Unlock()
 
 	if !i.aDone.Load() {
-		a, err := allocate(logger, i.ID)
+		a, err := allocateFn(logger, i.ID)
 		if err != nil {
 			return a, err
 		}


### PR DESCRIPTION
Only allocate memory for a process if a probe requires the allocation.

Move the allocation functionality to be a method of the process.Info. This is intrinsically linked to a single process, therefore, encapsulate the functionality as a method.