### PR TITLE
fix legacy otel global instrumentation parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
   The `auto` package no longer supports process discovery (note: the built binary (`auto/cli`) still supports process discovery).
   Once a target process has been identified, use `WithPID` to configure `Instrumentation` instead. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
 
+### Fixed
+
+- Fix spans parsing from eBPF for the legacy (go version < 1.24 otel-go < 1.33) otel global instrumentation. ([#1960](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1960))
+
 ## [v0.21.0] - 2025-02-18
 
 > [!WARNING]  

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -46,11 +46,11 @@ typedef struct tracer_id {
 } tracer_id_t;
 
 struct control_t {
-    u32 kind; // Required to be 1.
+    u64 kind; // Required to be 1.
 };
 
 struct otel_span_t {
-    u32 kind; // Required to be 0.
+    u64 kind; // Required to be 0.
     BASE_SPAN_PROPERTIES
     struct span_name_t span_name;
     otel_status_t status;
@@ -622,6 +622,7 @@ int uprobe_End(struct pt_regs *ctx) {
         return 0;
     }
     span->end_time = bpf_ktime_get_ns();
+    span->kind = 0;
     stop_tracking_span(&span->sc, &span->psc);
 
     output_span_event(ctx, span, sizeof(*span), &span->sc);

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_arm64_bpfel.go
@@ -13,8 +13,7 @@ import (
 )
 
 type bpfOtelSpanT struct {
-	Kind      uint32
-	_         [4]byte
+	Kind      uint64
 	StartTime uint64
 	EndTime   uint64
 	Sc        bpfSpanContext

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_x86_bpfel.go
@@ -13,8 +13,7 @@ import (
 )
 
 type bpfOtelSpanT struct {
-	Kind      uint32
-	_         [4]byte
+	Kind      uint64
 	StartTime uint64
 	EndTime   uint64
 	Sc        bpfSpanContext

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/probe.go
@@ -210,7 +210,7 @@ func New(logger *slog.Logger) probe.Probe {
 	}
 }
 
-type recordKind uint32
+type recordKind uint64
 
 const (
 	recordKindTelemetry recordKind = iota
@@ -236,7 +236,6 @@ func (c *converter) decodeEvent(record perf.Record) (*event, error) {
 	switch kind {
 	case recordKindTelemetry:
 		e = new(event)
-		reader.Reset(record.RawSample)
 		err = binary.Read(reader, binary.LittleEndian, e)
 	case recordKindConrol:
 		if c.uprobeNewStart != nil {


### PR DESCRIPTION
following #1405 this PR fixes the parsing of spans by:
1. Avoiding to reset the reader after reading the `kind` prefix. This would cause us to re-read the kind as part of the span fields.
2. Use uint64 for the kind to avoid padding.

Before this change we got spans like:
```JSON
 "scopeSpans": [
                {
                  "scope": {
                    "name": "go.opentelemetry.io/otel/sdk/tracer"
                  },
                  "spans": [
                    {
                      "traceId": "9P2JaEMBAADhuQuhqs6R4A==",
                      "spanId": "J1EhnD3aoX8=",
                      "parentSpanId": "J1EhnD3aoX8=",
                      "name": "\u0001",
                      "kind": "SPAN_KIND_CLIENT",
                      "startTimeUnixNano": "1741343746803724357",
                      "endTimeUnixNano": "1741345135831995695",
                      "status": {}
                    }
                  ]
                }
              ]
```

note the "\u0001" which is moved to the span name instead of the kind.