### PR TITLE
Add a dockerignore

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,13 @@
+*
+
+# must-have toplevel files
+!/go.sum
+!/go.mod
+!*.go
+!/LICENSE
+
+# directories
+!/cli
+!/sdk
+!/internal/include
+!/internal/pkg


### PR DESCRIPTION
Stop copying the whole project when building the auto docker image. This causes unrelated changes to the parts of the codebase to invalidate the docker cache

This also stops using the `make` utility to build the project. Doing so brings in many steps outside of building the target binary (i.e. linting and running `go mod tidy`). Instead, run the go commands that are needed directly.