### PR TITLE
Stop adding `process.runtime.description` to resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Fix spans parsing from eBPF for the legacy (go version < 1.24 otel-go < 1.33) otel global instrumentation. ([#1960](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1960))
+- Stop adding `process.runtime.description` to `Resource` to follow OpenTelemetry semantic conventions. ([#1986](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1986))
 
 ## [v0.21.0] - 2025-02-18
 

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -277,16 +276,11 @@ func (c instConfig) res() (res *resource.Resource) {
 	if runName == "gc" {
 		runName = "go"
 	}
-	runDesc := fmt.Sprintf(
-		"go version %s %s/%s",
-		bi.GoVersion, runtime.GOOS, runtime.GOARCH,
-	)
 
 	attrs = append(
 		attrs,
 		semconv.ProcessRuntimeName(runName),
 		semconv.ProcessRuntimeVersion(bi.GoVersion),
-		semconv.ProcessRuntimeDescription(runDesc),
 	)
 
 	return res

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "process.runtime.description",
-            "value": {
-              "stringValue": "go version 1.24.1 linux/VALID_ARCH"
-            }
-          },
-          {
             "key": "process.runtime.name",
             "value": {
               "stringValue": "go"

--- a/internal/test/test_helpers/utilities.sh
+++ b/internal/test/test_helpers/utilities.sh
@@ -161,12 +161,6 @@ redact_json() {
 				end
 			| .resourceSpans[].scopeSpans|=sort_by(.scope.name)
 			| .resourceSpans[].scopeSpans[].spans|=sort_by(.kind)
-			| .resourceSpans[].resource.attributes[]? |= if 
-					(.key == "process.runtime.description") then
-					.value.stringValue |= sub("amd64|arm64"; "VALID_ARCH")
-				else
-					.
-				end
 			' > ${BATS_TEST_DIRNAME}/traces.json
 }
 


### PR DESCRIPTION
Fix #1983 