### PR TITLE
Fix demo sql syntax

### DIFF
--- a/examples/httpPlusdb/main.go
+++ b/examples/httpPlusdb/main.go
@@ -24,9 +24,9 @@ const (
 	email TEXT NOT NULL,
 	phone TEXT NOT NULL);`
 
-	tableInsertion = `INSERT INTO 'contacts'
-	('first_name', 'last_name', 'email', 'phone') VALUES
-	('Moshe', 'Levi', 'moshe@gmail.com', '052-1234567');`
+	tableInsertion = "INSERT INTO `contacts` " +
+		"(`first_name`, `last_name`, `email`, `phone`) VALUES " +
+		"('Moshe', 'Levi', 'moshe@gmail.com', '052-1234567');"
 )
 
 // Server is Http server that exposes multiple endpoints.


### PR DESCRIPTION
In demo`httpPlusdb`, the definition of `tableInsertion` is:

```
tableInsertion = `INSERT INTO 'contacts'
	('first_name', 'last_name', 'email', 'phone') VALUES
	('Moshe', 'Levi', 'moshe@gmail.com', '052-1234567');`
```

SQL typically uses backticks (`) or double quotes (") for identifiers (table/column names), not single quotes which are for string values, which will cause the sqlparser to fail parsing.

<img width="851" alt="截屏2025-03-20 11 49 06" src="https://github.com/user-attachments/assets/f41b37b6-e2b9-48c2-8e5c-96cd89abed5e" />


The original variable definition prevents us from setting `db.query.summary` as the span name(Originally using default field `DB`).

after:
<img width="1726" alt="Clipboard_Screenshot_1742460781" src="https://github.com/user-attachments/assets/f507a53b-8447-4244-8db8-869a519766b2" />

