### PR TITLE
Add `docker-dev` make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM  --platform=$BUILDPLATFORM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS base
+FROM --platform=$BUILDPLATFORM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS base
 
 RUN apt-get update && apt-get install -y curl clang gcc llvm make libbpf-dev
+
+FROM --platform=$BUILDPLATFORM base AS builder
 
 WORKDIR /usr/src/go.opentelemetry.io/auto/
 
@@ -13,7 +15,6 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg \
     go mod download && go mod verify
 
-FROM --platform=$BUILDPLATFORM base AS builder
 COPY . .
 
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,15 @@ docker-build:
 docker-build-base:
 	docker buildx build -t $(IMG_NAME_BASE) --target base .
 
+docker-dev: docker-build-base
+	@docker run \
+		-it \
+		--rm \
+		-v "$(REPODIR)":/usr/src/go.opentelemetry.io/auto \
+		-w /usr/src/go.opentelemetry.io/auto \
+		$(IMG_NAME_BASE) \
+		/bin/bash
+
 LIBBPF_VERSION ?= "< 1.5, >= 1.4.7"
 LIBBPF_DEST ?= "$(REPODIR)/internal/include/libbpf"
 .PHONY: synclibbpf


### PR DESCRIPTION
It was asked in #1962 that a way be proved for development in the Debian image of built docker container. This adds a make that target allows developers to run the full code-base from within a docker container.