### PR TITLE
Upgrade OTel semconv to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Cache offsets for `go.opentelemetry.io/otel@v1.35.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
 - Cache offsets for `golang.org/x/net` `0.37.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
 
+### Changed
+
+- Upgrade OpenTelemetry semantic conventions to `v1.30.0`. ([#2032](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2032))
+
 ### Removed
 
 - Build support for Go 1.22 has been removed.

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation"
 	dbSql "go.opentelemetry.io/auto/internal/pkg/instrumentation/bpf/database/sql"

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -19,7 +19,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/probe/sampling"
 	"go.opentelemetry.io/auto/internal/pkg/process"

--- a/internal/pkg/instrumentation/bpf/database/sql/probe.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe.go
@@ -14,7 +14,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/probe_test.go
@@ -11,7 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/probe.go
@@ -9,7 +9,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 
@@ -116,9 +116,9 @@ func processFn(e *event) ptrace.SpanSlice {
 		semconv.MessagingOperationTypeReceive,
 		semconv.MessagingDestinationPartitionID(strconv.Itoa(int(e.Partition))),
 		semconv.MessagingDestinationName(topic),
-		semconv.MessagingKafkaMessageOffsetKey.Int64(e.Offset),
+		semconv.MessagingKafkaOffsetKey.Int64(e.Offset),
 		semconv.MessagingKafkaMessageKey(unix.ByteSliceToString(e.Key[:])),
-		semconv.MessagingKafkaConsumerGroup(unix.ByteSliceToString(e.ConsumerGroup[:])),
+		semconv.MessagingConsumerGroupName(unix.ByteSliceToString(e.ConsumerGroup[:])),
 	)
 
 	return spans

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/probe_test.go
@@ -11,7 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
@@ -60,9 +60,9 @@ func TestProbeConvertEvent(t *testing.T) {
 			semconv.MessagingOperationTypeReceive,
 			semconv.MessagingDestinationPartitionID("12"),
 			semconv.MessagingDestinationName("topic1"),
-			semconv.MessagingKafkaMessageOffset(42),
+			semconv.MessagingKafkaOffset(42),
 			semconv.MessagingKafkaMessageKey("key1"),
-			semconv.MessagingKafkaConsumerGroup("test consumer group"),
+			semconv.MessagingConsumerGroupName("test consumer group"),
 		)
 		return spans
 	}()

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/probe.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/probe.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 
@@ -93,7 +93,7 @@ type event struct {
 func processFn(e *event) ptrace.SpanSlice {
 	globalTopic := unix.ByteSliceToString(e.GlobalTopic[:])
 
-	attrs := []attribute.KeyValue{semconv.MessagingSystemKafka, semconv.MessagingOperationTypePublish}
+	attrs := []attribute.KeyValue{semconv.MessagingSystemKafka, semconv.MessagingOperationTypeSend}
 	if len(globalTopic) > 0 {
 		attrs = append(attrs, semconv.MessagingDestinationName(globalTopic))
 	}

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/probe_test.go
@@ -11,7 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"
@@ -70,7 +70,7 @@ func TestProbeConvertEvent(t *testing.T) {
 			semconv.MessagingKafkaMessageKey("key1"),
 			semconv.MessagingDestinationName("topic1"),
 			semconv.MessagingSystemKafka,
-			semconv.MessagingOperationTypePublish,
+			semconv.MessagingOperationTypeSend,
 			semconv.MessagingBatchMessageCount(2),
 		)
 
@@ -87,7 +87,7 @@ func TestProbeConvertEvent(t *testing.T) {
 			semconv.MessagingKafkaMessageKey("key2"),
 			semconv.MessagingDestinationName("topic2"),
 			semconv.MessagingSystemKafka,
-			semconv.MessagingOperationTypePublish,
+			semconv.MessagingOperationTypeSend,
 			semconv.MessagingBatchMessageCount(2),
 		)
 

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/probe.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/probe.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/net/http/client/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/probe_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/instrumentation/bpf/net/http/http_event.go
+++ b/internal/pkg/instrumentation/bpf/net/http/http_event.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"golang.org/x/sys/unix"
 )
 

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 

--- a/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
+++ b/internal/pkg/instrumentation/bpf/net/http/server/probe_test.go
@@ -11,7 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/context"

--- a/internal/pkg/opentelemetry/controller_test.go
+++ b/internal/pkg/opentelemetry/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/internal/pkg/instrumentation/utils"

--- a/internal/test/e2e/autosdk/traces.json
+++ b/internal/test/e2e/autosdk/traces.json
@@ -41,7 +41,7 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
           "schemaUrl": "https://some_schema",

--- a/internal/test/e2e/databasesql/traces.json
+++ b/internal/test/e2e/databasesql/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/database/sql",
             "version": "v0.21.0"
@@ -203,7 +203,7 @@
           ]
         },
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.21.0"

--- a/internal/test/e2e/gin/traces.json
+++ b/internal/test/e2e/gin/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.21.0"

--- a/internal/test/e2e/grpc/traces.json
+++ b/internal/test/e2e/grpc/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/google.golang.org/grpc",
             "version": "v0.21.0"

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -73,7 +73,7 @@
                 {
                   "key": "messaging.operation.type",
                   "value": {
-                    "stringValue": "publish"
+                    "stringValue": "send"
                   }
                 },
                 {
@@ -114,7 +114,7 @@
                 {
                   "key": "messaging.operation.type",
                   "value": {
-                    "stringValue": "publish"
+                    "stringValue": "send"
                   }
                 },
                 {
@@ -159,7 +159,7 @@
                   }
                 },
                 {
-                  "key": "messaging.kafka.message.offset",
+                  "key": "messaging.kafka.offset",
                   "value": {
                     "intValue": "0"
                   }
@@ -171,7 +171,7 @@
                   }
                 },
                 {
-                  "key": "messaging.kafka.consumer.group",
+                  "key": "messaging.consumer.group.name",
                   "value": {
                     "stringValue": "some group id"
                   }

--- a/internal/test/e2e/kafka-go/traces.json
+++ b/internal/test/e2e/kafka-go/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/github.com/segmentio/kafka-go",
             "version": "v0.21.0"

--- a/internal/test/e2e/kafka-go/verify.bats
+++ b/internal/test/e2e/kafka-go/verify.bats
@@ -49,13 +49,13 @@ SCOPE="go.opentelemetry.io/auto/github.com/segmentio/kafka-go"
   assert_equal "$partition" '"0"'
 }
 
-@test "consumer :: valid {messaging.kafka.message.offset}" {
-  offset=$(consumer_span_attributes_for ${SCOPE} | jq "select(.key == \"messaging.kafka.message.offset\").value.intValue" | sort )
+@test "consumer :: valid {messaging.kafka.offset}" {
+  offset=$(consumer_span_attributes_for ${SCOPE} | jq "select(.key == \"messaging.kafka.offset\").value.intValue" | sort )
   assert_equal "$offset" '"0"'
 }
 
 @test "consumer :: valid {messaging.kafka.consumer.group}" {
-  consumer_group=$(consumer_span_attributes_for ${SCOPE} | jq "select(.key == \"messaging.kafka.consumer.group\").value.stringValue" | sort )
+  consumer_group=$(consumer_span_attributes_for ${SCOPE} | jq "select(.key == \"messaging.consumer.group.name\").value.stringValue" | sort )
   assert_equal "$consumer_group" '"some group id"'
 }
 

--- a/internal/test/e2e/nethttp/traces.json
+++ b/internal/test/e2e/nethttp/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.21.0"

--- a/internal/test/e2e/nethttp_custom/traces.json
+++ b/internal/test/e2e/nethttp_custom/traces.json
@@ -41,10 +41,10 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
-          "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+          "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
           "scope": {
             "name": "go.opentelemetry.io/auto/net/http",
             "version": "v0.21.0"

--- a/internal/test/e2e/otelglobal/traces.json
+++ b/internal/test/e2e/otelglobal/traces.json
@@ -41,7 +41,7 @@
           }
         ]
       },
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
+      "schemaUrl": "https://opentelemetry.io/schemas/1.30.0",
       "scopeSpans": [
         {
           "schemaUrl": "https://some_schema",

--- a/sdk/span.go
+++ b/sdk/span.go
@@ -17,7 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 

--- a/sdk/span_test.go
+++ b/sdk/span_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/auto/sdk/internal/telemetry"


### PR DESCRIPTION
Changes:
  - [v1.27.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0)
  - [v1.28.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.28.0)
  - [v1.29.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.29.0)
  - [v1.30.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.30.0)