### PR TITLE
Unpin otel collector version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - The `process.runtime.version` resource attribute is now the exact value returned from `debug` to match what OpenTelemetry semantic conventions recommend. ([#1985](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1985))
 - Stop adding `process.runtime.description` to `Resource` to follow OpenTelemetry semantic conventions. ([#1986](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1986))
 - Reset Kafka producer span underlying memory before each span. ([#1937](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1937))
+- Stop pinning collector image in e2e tests. ([#2072](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2072))
 
 ## [v0.21.0] - 2025-02-18
 

--- a/renovate.json
+++ b/renovate.json
@@ -33,5 +33,19 @@
       "matchPackageNames": ["golang.org/x/**"],
       "groupName": "golang.org/x"
     }
+    {
+      "matchManagers": ["regex"],
+      "matchPackagePatterns": ["otel/opentelemetry-collector-contrib"],
+      "groupName": "otel-collector"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [".github/workflows/e2e/k8s/.*\\.ya?ml"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>otel/opentelemetry-collector-contrib)\\s*tag:\\s*\"?(?<currentValue>[^\"]+)\"?"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/1441

Make use of Renovabot's [Custom Manager using Regex](https://docs.renovatebot.com/modules/manager/regex/) to unpin the otel collector image for e2e tests.