### PR TITLE
Replace BATS with Go testing in `autosdk`

### DIFF
--- a/internal/test/e2e/autosdk/integration_test.go
+++ b/internal/test/e2e/autosdk/integration_test.go
@@ -6,10 +6,146 @@ package autosdk
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/goleak"
 
 	"go.opentelemetry.io/auto/internal/test/e2e"
 )
 
+// scopeName defines the instrumentation scope name used in the trace.
+const scopeName = "go.opentelemetry.io/auto/internal/test/e2e/autosdk"
+
+// Y2K (January 1, 2000).
+var y2k = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
 func TestIntegration(t *testing.T) {
-	e2e.TestIntegration(t, "./cmd", ".")
+	if testing.Short() {
+		t.Skip("skipping long-running integration test in short mode.")
+	}
+
+	defer goleak.VerifyNone(t)
+
+	traces := e2e.RunInstrumentation(t, "./cmd")
+	scopes := e2e.ScopeSpansByName(traces, scopeName)
+	require.NotEmpty(t, scopes)
+
+	t.Run("ResourceAttribute/ServiceName", func(t *testing.T) {
+		val, err := e2e.ResourceAttribute(traces, "service.name")
+		require.NoError(t, err)
+		assert.Equal(t, "sample-app", val.AsString())
+	})
+
+	t.Run("Scope", func(t *testing.T) {
+		assert.Equal(t, scopeName, scopes[0].Scope().Name(), "scope name")
+		assert.Equal(t, "v1.23.42", scopes[0].Scope().Version(), "scope version")
+	})
+
+	t.Run("SchemaURL", func(t *testing.T) {
+		assert.Equal(t, "https://some_schema", scopes[0].SchemaUrl())
+	})
+
+	mainSpan, err := e2e.SpanByName(scopes, "main")
+	require.NoError(t, err)
+	t.Run("MainSpan", func(t *testing.T) {
+		e2e.AssertTraceID(t, mainSpan.TraceID(), "trace ID")
+
+		e2e.AssertSpanID(t, mainSpan.SpanID(), "span ID")
+
+		assert.Equal(t, y2k, mainSpan.StartTimestamp().AsTime(), "start time")
+		assert.Equal(t, y2k.Add(5*time.Second), mainSpan.EndTimestamp().AsTime(), "end time")
+
+		assert.Equal(t, ptrace.SpanKindInternal, mainSpan.Kind(), "span kind")
+
+		status := mainSpan.Status()
+		assert.Equal(t, ptrace.StatusCodeError, status.Code(), "status code")
+		assert.Equal(t, "application error", status.Message(), "status message")
+
+		t.Run("Event", func(t *testing.T) {
+			event, err := e2e.EventByName(mainSpan, "exception")
+			require.NoError(t, err)
+
+			assert.Equal(t, y2k.Add(2*time.Second), event.Timestamp().AsTime(), "event time")
+
+			attrs := e2e.AttributesMap(event.Attributes())
+			assert.Equal(t, int64(11), attrs["impact"].Int(), "event attribute impact")
+			assert.Equal(
+				t,
+				"*errors.errorString",
+				attrs["exception.type"].Str(),
+				"event attribute exception type",
+			)
+			assert.Equal(
+				t,
+				"broken",
+				attrs["exception.message"].Str(),
+				"event attribute exception message",
+			)
+			assert.NotEmpty(
+				t,
+				attrs["exception.stacktrace"].Str(),
+				"event attribute exception stacktrace",
+			)
+		})
+	})
+
+	sigSpan, err := e2e.SpanByName(scopes, "sig")
+	require.NoError(t, err)
+	t.Run("SigSpan", func(t *testing.T) {
+		assert.Equal(t, mainSpan.TraceID(), sigSpan.TraceID(), "trace ID")
+
+		e2e.AssertSpanID(t, sigSpan.SpanID(), "span ID")
+
+		assert.Equal(t, mainSpan.SpanID(), sigSpan.ParentSpanID(), "parent span ID")
+
+		assert.Equal(
+			t,
+			y2k.Add(10*time.Microsecond),
+			sigSpan.StartTimestamp().AsTime(),
+			"start time",
+		)
+		assert.Equal(t, y2k.Add(110*time.Microsecond), sigSpan.EndTimestamp().AsTime(), "end time")
+
+		assert.Equal(t, ptrace.SpanKindInternal, sigSpan.Kind(), "span kind")
+	})
+
+	runSpan, err := e2e.SpanByName(scopes, "Run")
+	require.NoError(t, err)
+	t.Run("RunSpan", func(t *testing.T) {
+		assert.Equal(t, mainSpan.TraceID(), runSpan.TraceID(), "trace ID")
+
+		e2e.AssertSpanID(t, runSpan.SpanID(), "span ID")
+
+		assert.Equal(t, mainSpan.SpanID(), runSpan.ParentSpanID(), "parent span ID")
+
+		assert.Equal(
+			t,
+			y2k.Add(500*time.Microsecond),
+			runSpan.StartTimestamp().AsTime(),
+			"start time",
+		)
+		assert.Equal(t, y2k.Add(1*time.Second), runSpan.EndTimestamp().AsTime(), "end time")
+
+		assert.Equal(t, ptrace.SpanKindServer, runSpan.Kind(), "span kind")
+
+		attrs := e2e.AttributesMap(runSpan.Attributes())
+		assert.Equal(t, "Alice", attrs["user"].Str(), "user attribute")
+		assert.True(t, attrs["admin"].Bool(), "admin attribute")
+
+		t.Run("Link", func(t *testing.T) {
+			if !assert.Equal(t, 1, runSpan.Links().Len(), "number of links") {
+				return
+			}
+
+			link := runSpan.Links().At(0)
+			assert.Equal(t, sigSpan.TraceID(), link.TraceID(), "link trace ID")
+			assert.Equal(t, sigSpan.SpanID(), link.SpanID(), "link span ID")
+
+			attrs := e2e.AttributesMap(link.Attributes())
+			assert.Equal(t, "Hello World", attrs["data"].Str(), "link attribute data")
+		})
+	})
 }

--- a/internal/test/e2e/go.mod
+++ b/internal/test/e2e/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/auto/sdk v1.1.0
 	go.opentelemetry.io/collector/pdata v1.30.0
@@ -29,6 +30,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -60,6 +62,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.63.0 // indirect

--- a/internal/test/e2e/verify.go
+++ b/internal/test/e2e/verify.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing" // nolint:depguard  // This is a testing utility package.
+
+	"github.com/stretchr/testify/assert" // nolint:depguard  // This is a testing utility package.
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// ResourceSpans returns all resource spans in the given trace data.
+func ResourceSpans(td ptrace.Traces) []ptrace.ResourceSpans {
+	var spans []ptrace.ResourceSpans
+	rs := td.ResourceSpans()
+	for i := range rs.Len() {
+		spans = append(spans, rs.At(i))
+	}
+	return spans
+}
+
+// ResourceAttribute returns the value of a specific resource attribute
+// if found.
+func ResourceAttribute(td ptrace.Traces, key string) (pcommon.Value, error) {
+	for _, rs := range ResourceSpans(td) {
+		attrs := rs.Resource().Attributes()
+		if val, ok := attrs.Get(key); ok {
+			return val, nil
+		}
+	}
+	return pcommon.NewValueEmpty(), fmt.Errorf("resource attribute %q not found", key)
+}
+
+// ScopeSpansByName filters scope spans matching the provided scope
+// name.
+func ScopeSpansByName(td ptrace.Traces, name string) []ptrace.ScopeSpans {
+	var result []ptrace.ScopeSpans
+	for _, rs := range ResourceSpans(td) {
+		scopes := rs.ScopeSpans()
+		for i := range scopes.Len() {
+			ss := scopes.At(i)
+			if ss.Scope().Name() == name {
+				result = append(result, ss)
+			}
+		}
+	}
+	return result
+}
+
+// SpanByName returns the first span with the specified name from a
+// set of scope spans.
+func SpanByName(scopeSpans []ptrace.ScopeSpans, name string) (ptrace.Span, error) {
+	for _, ss := range scopeSpans {
+		spans := ss.Spans()
+		for i := range spans.Len() {
+			span := spans.At(i)
+			if span.Name() == name {
+				return span, nil
+			}
+		}
+	}
+	return ptrace.NewSpan(), fmt.Errorf("span %q not found", name)
+}
+
+// AttributesMap converts the given attribute map to a native Go map.
+func AttributesMap(attrs pcommon.Map) map[string]pcommon.Value {
+	result := make(map[string]pcommon.Value)
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		result[k] = v
+		return true
+	})
+	return result
+}
+
+// EventByName finds the first event in the span matching the given
+// name.
+func EventByName(span ptrace.Span, name string) (ptrace.SpanEvent, error) {
+	events := span.Events()
+	for i := range events.Len() {
+		event := events.At(i)
+		if event.Name() == name {
+			return event, nil
+		}
+	}
+	return ptrace.NewSpanEvent(), fmt.Errorf("event %q not found", name)
+}
+
+// LinkByTraceAndSpanID locates a link in the span matching the given
+// trace and span ID.
+func LinkByTraceAndSpanID(span ptrace.Span, traceID, spanID string) (ptrace.SpanLink, error) {
+	links := span.Links()
+	for i := range links.Len() {
+		link := links.At(i)
+		tidB := [16]byte(link.TraceID())
+		tid := hex.EncodeToString(tidB[:])
+		sidB := [8]byte(link.SpanID())
+		sid := hex.EncodeToString(sidB[:])
+		if tid == traceID && sid == spanID {
+			return link, nil
+		}
+	}
+	return ptrace.NewSpanLink(), errors.New("link not found")
+}
+
+var traceIDRe = regexp.MustCompile(`^[a-f0-9]{32}$`)
+
+func AssertTraceID(t *testing.T, traceID pcommon.TraceID, msgAndArgs ...any) bool {
+	tidB := [16]byte(traceID)
+	tid := hex.EncodeToString(tidB[:])
+	return assert.Regexp(t, traceIDRe, tid, msgAndArgs...)
+}
+
+var spanIDRe = regexp.MustCompile(`^[a-f0-9]{16}$`)
+
+func AssertSpanID(t *testing.T, spanID pcommon.SpanID, msgAndArgs ...any) bool {
+	sidB := [8]byte(spanID)
+	sid := hex.EncodeToString(sidB[:])
+	return assert.Regexp(t, spanIDRe, sid, msgAndArgs...)
+}


### PR DESCRIPTION
- Add Go testing utilities to the `e2e` package
- Update integration test for `autosdk` to use new e2e testing utility
- Remove BATS definitions for `autosdk`

The plan is to do the same for all other e2e tests (replace BATS) once this merges. This is scoped to only `autosdk` to keep the size of this PR down.

Part of a resolution for #2137

Replaces #2163 