### PR TITLE
Update database end-to-end program

### DIFF
--- a/internal/test/e2e/databasesql/verify.bats
+++ b/internal/test/e2e/databasesql/verify.bats
@@ -5,40 +5,36 @@ load ../../test_helpers/utilities.sh
 SCOPE="go.opentelemetry.io/auto/database/sql"
 
 @test "${SCOPE} :: includes db.query.text attribute" {
-  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[0])
-  assert_equal "$result" '"SELECT * FROM contacts"'
-  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[1])
-  assert_equal "$result" "\"INSERT INTO contacts (first_name) VALUES ('Mike')\""
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[2])
-  assert_equal "$result" "\"UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'\""
+  assert_equal "$result" '"SELECT * FROM contacts"'
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[3])
-  assert_equal "$result" "\"DELETE FROM contacts WHERE first_name = 'Mike'\""
+  assert_equal "$result" "\"INSERT INTO contacts (first_name) VALUES ('Mike')\""
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[4])
-  assert_equal "$result" "\"DROP TABLE contacts\""
+  assert_equal "$result" "\"UPDATE contacts SET last_name = 'Santa' WHERE first_name = 'Mike'\""
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[5])
+  assert_equal "$result" "\"DELETE FROM contacts WHERE first_name = 'Mike'\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[6])
+  assert_equal "$result" "\"DROP TABLE contacts\""
+  result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"db.query.text\").value.stringValue" | jq -Rn '[inputs]' | jq -r .[7])
   assert_equal "$result" "\"syntax error\""
 }
 
 @test "${SCOPE} :: span name is set correctly" {
-  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[0])
-  assert_equal "$result" '"SELECT contacts"'
-  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[1])
-  assert_equal "$result" '"INSERT contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[2])
-  assert_equal "$result" '"UPDATE contacts"'
+  assert_equal "$result" '"SELECT contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[3])
-  assert_equal "$result" '"DELETE contacts"'
+  assert_equal "$result" '"INSERT contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[4])
-  assert_equal "$result" '"DB"'
+  assert_equal "$result" '"UPDATE contacts"'
   result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[5])
+  assert_equal "$result" '"DELETE contacts"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[6])
+  assert_equal "$result" '"DB"'
+  result=$(span_names_for ${SCOPE} | jq -Rn '[inputs]' | jq -r .[7])
   assert_equal "$result" '"DB"'
 }
 
 @test "${SCOPE} :: trace ID present and valid in all spans" {
-  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[0])
-  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
-  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[1])
-  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
   trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[2])
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
   trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[3])
@@ -47,13 +43,13 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
   trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[5])
   assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[6])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
+  trace_id=$(spans_from_scope_named ${SCOPE} | jq ".traceId" | jq -Rn '[inputs]' | jq -r .[7])
+  assert_regex "$trace_id" ${MATCH_A_TRACE_ID}
 }
 
 @test "${SCOPE} :: span ID present and valid in all spans" {
-  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[0])
-  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
-  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[1])
-  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
   span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[2])
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
   span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[3])
@@ -62,13 +58,13 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
   span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[5])
   assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[6])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
+  span_id=$(spans_from_scope_named ${SCOPE} | jq ".spanId" | jq -Rn '[inputs]' | jq -r .[7])
+  assert_regex "$span_id" ${MATCH_A_SPAN_ID}
 }
 
 @test "${SCOPE} :: parent span ID present and valid in all spans" {
-  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[0])
-  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
-  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[1])
-  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[2])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[3])
@@ -76,5 +72,9 @@ SCOPE="go.opentelemetry.io/auto/database/sql"
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[4])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
   parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[5])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[6])
+  assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
+  parent_span_id=$(spans_from_scope_named ${SCOPE} | jq ".parentSpanId" | jq -Rn '[inputs]' | jq -r .[7])
   assert_regex "$parent_span_id" ${MATCH_A_SPAN_ID}
 }


### PR DESCRIPTION
- Do not use HTTP. This is conflicting with other tests and is unneeded[^1].
  - Replace the HTTP parent span with one from the OTel global API.
- Run all DB queries after auto-instrumentation starts so there is not indeterminate results when the auto-instrumentation starts sooner than expected.
- Use error handling instead of panics.
- Update bats with new span indexes.

[^1]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/actions/runs/14644532137/job/41095136897?pr=2178