### PR TITLE
telemetry: add tests for  protoInt64 and protoUint64 JSON unmarshaling

### DIFF
--- a/sdk/internal/telemetry/number.go
+++ b/sdk/internal/telemetry/number.go
@@ -41,7 +41,7 @@ func (i *protoInt64) UnmarshalJSON(data []byte) error {
 // strings or integers.
 type protoUint64 uint64
 
-// Int64 returns the protoUint64 as a uint64.
+// Uint64 returns the protoUint64 as a uint64.
 func (i *protoUint64) Uint64() uint64 { return uint64(*i) }
 
 // UnmarshalJSON decodes both strings and integers.

--- a/sdk/internal/telemetry/number_test.go
+++ b/sdk/internal/telemetry/number_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import "testing"
+
+func TestProtoInt64Encoding(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  []byte
+		Expect protoInt64
+	}{
+		{
+			Name:   "string negative int64",
+			Input:  []byte(`"-123"`),
+			Expect: protoInt64(-123),
+		},
+		{
+			Name:   "string positive int64",
+			Input:  []byte(`"123"`),
+			Expect: protoInt64(123),
+		},
+		{
+			Name:   "negative int64",
+			Input:  []byte(`-123`),
+			Expect: protoInt64(-123),
+		},
+		{
+			Name:   "positive int64",
+			Input:  []byte(`123`),
+			Expect: protoInt64(123),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, runJSONUnmarshalTest(tc.Expect, tc.Input))
+	}
+}
+
+func TestProtoUInt64(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  []byte
+		Expect protoUint64
+	}{
+		{
+			Name:   "string uint64",
+			Input:  []byte(`"1"`),
+			Expect: protoUint64(1),
+		},
+		{
+			Name:   "string uint64",
+			Input:  []byte(`1`),
+			Expect: protoUint64(1),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, runJSONUnmarshalTest(tc.Expect, tc.Input))
+	}
+}

--- a/sdk/internal/telemetry/number_test.go
+++ b/sdk/internal/telemetry/number_test.go
@@ -50,7 +50,7 @@ func TestProtoUint64(t *testing.T) {
 			Expect: protoUint64(1),
 		},
 		{
-			Name:   "string uint64",
+			Name:   "uint64",
 			Input:  []byte(`1`),
 			Expect: protoUint64(1),
 		},

--- a/sdk/internal/telemetry/number_test.go
+++ b/sdk/internal/telemetry/number_test.go
@@ -38,7 +38,7 @@ func TestProtoInt64Encoding(t *testing.T) {
 	}
 }
 
-func TestProtoUInt64(t *testing.T) {
+func TestProtoUint64(t *testing.T) {
 	testCases := []struct {
 		Name   string
 		Input  []byte


### PR DESCRIPTION
Add tests for `protoInt64` and `protoUint64` JSON unmarshaling
