### PR TITLE
Release `v0.22.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+## [v0.22.0] - 2025-05-23
+
 ### Added
 
 - Cache offsets for `google.golang.org/grpc` `1.72.0-dev`. ([#1849](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1849))
@@ -24,7 +26,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Cache offsets for `google.golang.org/grpc` `1.71.0`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
 - Cache offsets for Go `1.23.7`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
 - Cache offsets for Go `1.24.1`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
-- Cache offsets for `go.opentelemetry.io/otel@v1.35.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
+- Cache offsets for `go.opentelemetry.io/otel` `v1.35.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
 - Cache offsets for `golang.org/x/net` `0.37.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
 - Cache offsets for `golang.org/x/net` `0.38.0`. ([#2063](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2063))
 - Cache offsets for `google.golang.org/grpc` `1.71.1`. ([#2078](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2078))
@@ -42,7 +44,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Cache offsets for `google.golang.org/grpc` `1.71.2`. ([#2319](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2319))
 - Cache offsets for `google.golang.org/grpc` `1.72.1`. ([#2319](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2319))
 - Cache offsets for `google.golang.org/grpc` `1.74.0-dev`. ([#2337](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2337))
-- Cache offsets for `go.opentelemetry.io/otel@v1.36.0`. ([#2352](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2352))
+- Cache offsets for `go.opentelemetry.io/otel` `v1.36.0`. ([#2352](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2352))
 
 ### Changed
 
@@ -59,13 +61,13 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 - Build support for Go 1.22 has been removed.
   Use Go >= 1.23 to develop and build the project. ([#1841](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1841))
-- The `WithGlobal` function is removed from `go.opentelemtry.io/auto`
+- The `WithGlobal` function is removed from `go.opentelemtry.io/auto`.
   This option is on by default. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
-- The `WithServiceName` function is removed from `go.opentelemtry.io/auto`
+- The `WithServiceName` function is removed from `go.opentelemtry.io/auto`.
   Use `WithServiceName` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
-- The `WithTraceExporter` function is removed from `go.opentelemtry.io/auto`
+- The `WithTraceExporter` function is removed from `go.opentelemtry.io/auto`.
   Use `WithTraceExporter` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
-- The `WithResourceAttributes` function is removed from `go.opentelemtry.io/auto`
+- The `WithResourceAttributes` function is removed from `go.opentelemtry.io/auto`.
   Use `WithResourceAttributes` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
 - Resolution of the environment variable `"OTEL_GO_AUTO_TARGET_EXE"` has been removed from `WithEnv`.
   Note, the built binary (`auto/cli`) still supports resolution and use of this value.
@@ -652,7 +654,8 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 This is the first release of OpenTelemetry Go Automatic Instrumentation.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/compare/v0.22.0...HEAD
+[v0.22.0]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.22.0
 [v0.21.0]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.21.0
 [v0.20.0]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.20.0
 [v0.19.0-alpha]: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.19.0-alpha

--- a/internal/test/e2e/go.mod
+++ b/internal/test/e2e/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/segmentio/kafka-go v0.4.48
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/auto v0.21.0
+	go.opentelemetry.io/auto v0.22.0
 	go.opentelemetry.io/auto/sdk v1.1.0
 	go.opentelemetry.io/collector/pdata v1.32.0
 	go.opentelemetry.io/otel v1.36.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/golangci/golangci-lint/v2 v2.1.6
 	github.com/google/go-licenses/v2 v2.0.0-alpha.1
-	go.opentelemetry.io/auto v0.21.0
+	go.opentelemetry.io/auto v0.22.0
 	go.opentelemetry.io/build-tools/crosslink v0.23.1
 	go.opentelemetry.io/build-tools/dbotconf v0.23.1
 	go.opentelemetry.io/build-tools/multimod v0.23.1

--- a/version.go
+++ b/version.go
@@ -5,5 +5,5 @@ package auto
 
 // Version is the current release version of OpenTelemetry Go auto-instrumentation in use.
 func Version() string {
-	return "v0.21.0"
+	return "v0.22.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   auto:
-    version: v0.21.0
+    version: v0.22.0
     modules:
       - go.opentelemetry.io/auto
   sdk:


### PR DESCRIPTION
### Added

- Cache offsets for `google.golang.org/grpc` `1.72.0-dev`. ([#1849](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1849))
- The `go.opentelemtry.io/auto/pipeline` package is added. This package contains interface definitions for types that want to handle the telemetry generated by auto-instrumentation. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `go.opentelemtry.io/auto/pipeline/otelsdk` package is added. This package a default handler that uses the OpenTelemetry Go SDK to handle telemetry generated by auto-instrumentation. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `WithHandler` function is added to configure `Instrumentation` in `go.opentelemtry.io/auto` with the desired handler implementation. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The auto binary (built from `auto/cli`) can now be passed the target process PID directly using the `-target-pid` CLI option. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
- The auto binary (built from `auto/cli`) can now be passed the path of the target process executable directly using the `-target-exe` CLI option. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
- The auto binary (built from `auto/cli`) now resolves the target PID from the environment variable `"OTEL_GO_AUTO_TARGET_PID"` if no target options are passed. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
- The auto binary (built from `auto/cli`) will now only resolve the target process executable from the environment variable `"OTEL_GO_AUTO_TARGET_EXE"` if no target options are passed and `"OTEL_GO_AUTO_TARGET_PID"` is not set. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
- Cache offsets for `golang.org/x/net` `0.36.0`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
- Cache offsets for `google.golang.org/grpc` `1.71.0`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
- Cache offsets for Go `1.23.7`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
- Cache offsets for Go `1.24.1`. ([#1940](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1940))
- Cache offsets for `go.opentelemetry.io/otel` `v1.35.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
- Cache offsets for `golang.org/x/net` `0.37.0`. ([#1948](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1948))
- Cache offsets for `golang.org/x/net` `0.38.0`. ([#2063](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2063))
- Cache offsets for `google.golang.org/grpc` `1.71.1`. ([#2078](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2078))
- Cache offsets for Go `1.23.8`. ([#2081](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2081))
- Cache offsets for Go `1.24.2`. ([#2081](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2081))
- Cache offsets for `google.golang.org/grpc` `1.73.0-dev`. ([#2091](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2091))
- Cache offsets for `golang.org/x/net` `0.39.0`. ([#2107](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2107))
- The new `Multiplexer` type is added to `go.opentelemetry.io/auto/pipeline/otelsdk`. This type is used to support multiple process instrumentation using the same telemetry pipeline. ([#2016](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2016))
- Cache offsets for `google.golang.org/grpc` `1.72.0`. ([#2190](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2190))
- Cache offsets for `golang.org/x/net` `0.40.0`. ([#2281](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2281))
- Cache offsets for Go `1.23.9`. ([#2292](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2292))
- Cache offsets for Go `1.24.3`. ([#2292](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2292))
- Cache offsets for `github.com/segmentio/kafka-go` `0.4.48`. ([#2319](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2319))
- Cache offsets for `google.golang.org/grpc` `1.71.2`. ([#2319](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2319))
- Cache offsets for `google.golang.org/grpc` `1.72.1`. ([#2319](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2319))
- Cache offsets for `google.golang.org/grpc` `1.74.0-dev`. ([#2337](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2337))
- Cache offsets for `go.opentelemetry.io/otel` `v1.36.0`. ([#2352](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2352))

### Changed

- The `WithEnv` function no longer parses `OTEL_GO_AUTO_GLOBAL`. This is included by default. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `WithEnv` function no longer parses `OTEL_SERVICE_NAME` or `OTEL_TRACES_EXPORTER`. Use the `Handler` from `go.opentelemtry.io/auto/pipeline/otelsdk` with its own `WithEnv` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- Instrument spans created with the OpenTelemetry trace API from an empty context. ([#2001](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2001))
- Upgrade OpenTelemetry semantic conventions to `v1.30.0`. ([#2032](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2032))
- Modify how the pattern is fetch from `net/http.Request`. Now it uses `Request.Pattern` instead of `Request.pat.str` unless using go1.22, which continue using `Request.pat.str`. ([#2090](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2090))

### Removed

- Build support for Go 1.22 has been removed. Use Go >= 1.23 to develop and build the project. ([#1841](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1841))
- The `WithGlobal` function is removed from `go.opentelemtry.io/auto`. This option is on by default. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `WithServiceName` function is removed from `go.opentelemtry.io/auto`. Use `WithServiceName` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `WithTraceExporter` function is removed from `go.opentelemtry.io/auto`. Use `WithTraceExporter` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- The `WithResourceAttributes` function is removed from `go.opentelemtry.io/auto`. Use `WithResourceAttributes` in `go.opentelemtry.io/auto/pipeline/otelsdk` along with `WithHandler` to replace functionality. ([#1859](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1859))
- Resolution of the environment variable `"OTEL_GO_AUTO_TARGET_EXE"` has been removed from `WithEnv`.
  Note, the built binary (`auto/cli`) still supports resolution and use of this value.
  If using the `auto` package directly, you will need to resolve this value yourself and pass the discovered process PID using `WithPID`. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))
- The `WithTarget` function is removed. The `auto` package no longer supports process discovery (note: the built binary (`auto/cli`) still supports process discovery). Once a target process has been identified, use `WithPID` to configure `Instrumentation` instead. ([#1890](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1890))

### Fixed

- Fix spans parsing from eBPF for the legacy (go version < 1.24 otel-go < 1.33) otel global instrumentation. ([#1960](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1960))
- The `process.runtime.version` resource attribute is now the exact value returned from `debug` to match what OpenTelemetry semantic conventions recommend. ([#1985](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1985))
- Stop adding `process.runtime.description` to `Resource` to follow OpenTelemetry semantic conventions. ([#1986](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1986))
- Reset Kafka producer span underlying memory before each span. ([#1937](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1937))
- Stop pinning collector image in e2e tests. ([#2072](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2072))
- Fallback to avoid context propagation in `kafka-go` instrumentation if the kernel does not support `bpf_probe_write_user`. ([#2105](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2105))
- Make sure Go strings being read from eBPF are null terminated. ([#1936](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/1936))
- Handle dynamic goroutine stack resizes in the `autosdk` and `otel/trace` probes. ([#2263](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2263))