### PR TITLE
Change active_spans_by_span_ptr to LRU map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Add `telemetry.distro.version` resource attribute to the `otelsdk` handler. ([#2383](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2383))
+- `active_spans_by_span_ptr` eBPF map used in the traceglobal probe changed to LRU. ([#2509])(https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2509)
 
 ## [v0.22.1] - 2025-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 ### Fixed
 
 - Add `telemetry.distro.version` resource attribute to the `otelsdk` handler. ([#2383](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2383))
-- `active_spans_by_span_ptr` eBPF map used in the traceglobal probe changed to LRU. ([#2509])(https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2509)
+- `active_spans_by_span_ptr` eBPF map used in the traceglobal probe changed to LRU. ([#2509](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2509))
 
 ## [v0.22.1] - 2025-07-01
 

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -85,7 +85,7 @@ MAP_BUCKET_DEFINITION(go_tracer_with_schema_t, go_tracer_ptr)
 MAP_BUCKET_DEFINITION(go_tracer_with_scope_attributes_t, go_tracer_ptr)
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, void*);
 	__type(value, struct otel_span_t);
 	__uint(max_entries, MAX_CONCURRENT);


### PR DESCRIPTION
The generic usage of the trace global span creation code is something like:

```go
_, span := tracer.Start(ctx, fmt.Sprintf("Some span name"), opts...)
defer span.End(trace.WithTimestamp(ts.Add(100 * time.Microsecond)))
```

One problem that might potentially happen is if the user forgets to put the line that does span.End, or they incorrectly put it on a path in the function, such that it doesn't always run. In this scenario, the span start will never be complete. Since we have a BPF map that tracks the spans that have been started, this erroneous usage of the SDK API may cause permanent leak, since we'll never execute the removal of the span from the map.

To fix this, I'm changing the MAP definition to be an LRU map, so that in this case these stale old entries which are incomplete will be automatically purged, and while it won't fix the actual erroneous usage by the user, it will at least prevent us from permanently disabling the tracer SDK functionality.