### PR TITLE
chore: enable rangeValCopy rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,6 @@ linters:
       disabled-checks:
         - exitAfterDefer
         - hugeParam
-        - rangeValCopy
         - unnamedResult
       enable-all: true
     godot:

--- a/internal/test/e2e/kafka-go/cmd/main.go
+++ b/internal/test/e2e/kafka-go/cmd/main.go
@@ -148,7 +148,8 @@ func run(ctx context.Context) error {
 			"value", string(msg.Value),
 			"headers", msg.Headers,
 		)
-		for i, m := range msgs {
+		for i := range msgs {
+			m := &msgs[i]
 			if m.Topic == msg.Topic && bytes.Equal(m.Key, msg.Key) &&
 				bytes.Equal(m.Value, msg.Value) {
 				msgs = slices.Delete(msgs, i, i+1)


### PR DESCRIPTION
#### Description

Enables and fixes [rangeValCopy](https://go-critic.com/overview.html#rangevalcopy) rule from go-critic