### PR TITLE
Fix 32bit arch `int` overflow in `sdk`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -13,7 +13,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -117,7 +117,7 @@ jobs:
 
           # Stream test output to stdout and save to file for jq
           go test -v -run='^TestIntegration' | tee "$tmpfile"
-          
+
           # Fail if any "skip" action occurs under TestIntegration/
           go tool test2json < "$tmpfile" | jq -e '
             select(
@@ -129,7 +129,38 @@ jobs:
                 exit 1
             }
           rm "$tmpfile"
-          
+
+  sdk-compatibility-test:
+    strategy:
+      matrix:
+        go-version: ["stable", "oldstable"]
+        platform:
+          - os: ubuntu-latest
+            arch: "386"
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-22.04-arm
+            arch: arm64
+          - os: macos-13
+            arch: amd64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
+            arch: "386"
+          - os: windows-latest
+            arch: amd64
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/go.sum"
+      - name: Test sdk module
+        env:
+          GOARCH: ${{ matrix.platform.arch }}
+        run: cd sdk && go test -v ./...
   compatibility-test:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `uint32` bounding on 32 bit architectures in the `go.opentelemetry.io/auto/sdk` module. ([#2810](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/2810))
+
 ### Removed
 
 - Build support for [Go 1.23] has been removed.

--- a/sdk/tracer.go
+++ b/sdk/tracer.go
@@ -64,6 +64,8 @@ func (t *tracer) start(
 // start is used for testing.
 var start = func(context.Context, *span, *trace.SpanContext, *bool, *trace.SpanContext) {}
 
+var intToUint32Bound = min(math.MaxInt, math.MaxUint32)
+
 func (t tracer) traces(
 	name string,
 	cfg trace.SpanConfig,
@@ -85,12 +87,14 @@ func (t tracer) traces(
 	if limit := maxSpan.Links; limit == 0 {
 		n := len(links)
 		if n > 0 {
-			span.DroppedLinks = uint32(min(n, math.MaxUint32)) //nolint:gosec  // Bounds checked.
+			bounded := max(min(n, intToUint32Bound), 0)
+			span.DroppedLinks = uint32(bounded) //nolint:gosec  // Bounds checked.
 		}
 	} else {
 		if limit > 0 {
 			n := max(len(links)-limit, 0)
-			span.DroppedLinks = uint32(min(n, math.MaxUint32)) //nolint:gosec  // Bounds checked.
+			bounded := min(n, intToUint32Bound)
+			span.DroppedLinks = uint32(bounded) //nolint:gosec  // Bounds checked.
 			links = links[n:]
 		}
 		span.Links = convLinks(links)


### PR DESCRIPTION
Testing with `GOARCH=386`:

```
Error: ../../../go/pkg/mod/go.opentelemetry.io/auto/sdk@v1.2.0/tracer.go:88:38: math.MaxUint32 (untyped int constant 4294967295) overflows int
19
Error: ../../../go/pkg/mod/go.opentelemetry.io/auto/sdk@v1.2.0/tracer.go:93:38: math.MaxUint32 (untyped int constant 4294967295) overflows int
```