### PR TITLE
Temporarily fix broken rolldice example

### DIFF
--- a/examples/rolldice/user/go.mod
+++ b/examples/rolldice/user/go.mod
@@ -14,5 +14,3 @@ require (
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
-
-replace go.opentelemetry.io/auto/sdk => ../../../sdk

--- a/examples/rolldice/user/go.sum
+++ b/examples/rolldice/user/go.sum
@@ -13,6 +13,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=


### PR DESCRIPTION
This PR provides a temporary fix for the rolldice example that is currently failing to build, as reported in issue #2889.

**Problem**
The rolldice example image fails to build with the following error:
```
go: go.opentelemetry.io/auto/sdk@v1.2.1 (replaced by ../../../sdk): reading /sdk/go.mod: open /sdk/go.mod: no such file or directory
```

**Root Cause**
This issue appears to be related to changes introduced in PR #2790, which modified the project structure or dependency management in a way that affects the local module replacement.

**Temporary Solution**
This fix removes the problematic `replace` directive from `examples/rolldice/user/go.mod` and allows the dependency to be resolved normally from the published version.

**Why This is Temporary**
This is a temporary workaround because:
1. We need to analyze the changes made in PR #2790 more thoroughly to understand the underlying structural changes
2. Similar issues may occur again if directory structure or module paths are modified in the future without proper consideration of the examples
3. A more robust, permanent solution is needed to prevent this type of breakage from recurring

**Next Steps**
- [ ] Investigate the exact changes in PR #2790 that caused this issue
- [ ] Develop a more permanent solution that accounts for project structure changes
- [ ] Add safeguards to prevent similar issues in future structural modifications

Fixes #2889