### PR TITLE
Replace bitnami Kafka image with soldevelo/kafka

### DIFF
--- a/internal/test/e2e/kafka-go/cmd/dependencies.Dockerfile
+++ b/internal/test/e2e/kafka-go/cmd/dependencies.Dockerfile
@@ -1,1 +1,1 @@
-FROM bitnami/kafka:latest@sha256:f45d5b813412e1ef7ce67b467309a84e4c6dc03d7626a0b6da867db9b69bd107 AS kafka
+FROM soldevelo/kafka@sha256:b11fa51543b2e2345fefa807e0c8400544474e5dac622992fd29b050f009b6ae AS kafka


### PR DESCRIPTION
Soldevelo image is a drop-in replacement that remains fully compatible with Bitnami’s configuration and environment variables.

The Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.
Switching to Soldevelo’s maintained image ensures:
* continued compatibility with existing Kafka setup,
* availability of regular updates and security patches,
* use of an image from a trusted and open source provider.