### PR TITLE
Update macos runner

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -141,7 +141,7 @@ jobs:
             arch: amd64
           - os: ubuntu-22.04-arm
             arch: arm64
-          - os: macos-13
+          - os: macos-14
             arch: amd64
           - os: macos-latest
             arch: arm64


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/