### PR TITLE
Run clang-format inside a pinned docker image

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -19,9 +19,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Clang-Format
-        run: sudo apt-get install clang-format-19
-
       - name: Check Clang Format
         run: |
           # Check for modified C/C++ files
@@ -31,8 +28,12 @@ jobs:
             exit 0
           fi
 
-          # Run clang-format and check for changes
-          clang-format-19 -i $files
+          # Run clang-format from the docker image pinned in dependencies.Dockerfile
+          # to keep the version consistent with `make clang-format` and the
+          # local pre-commit hook.
+          image=$(awk '$4=="clang-format" {print $2}' dependencies.Dockerfile)
+          docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/workdir" -w /workdir "$image" \
+            clang-format -i $files
           if ! git diff --exit-code $files; then
             echo "Error: Some files are not formatted correctly. Please run clang-format on the modified files or use the provided pre-commit hook."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 
 ### Changed
 
-- The `clang-format` `make` target now runs inside a pinned Docker image to ensure a consistent `clang-format` version across contributors and CI. ([#3472](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/3472))
+- `clang-format` now runs inside a pinned Docker image in the `make clang-format` target, the `clang-format-check` CI workflow, and the local pre-commit hook to ensure a consistent `clang-format` version across contributors and CI. ([#3472](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/3472))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ OpenTelemetry Go Automatic Instrumentation adheres to [Semantic Versioning](http
 - Cache offsets for `google.golang.org/grpc` `1.80.0`. ([#3402](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/3402))
 - Cache offsets for `go.opentelemetry.io/otel` `v1.43.0`. ([#3430](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/3430))
 
+### Changed
+
+- The `clang-format` `make` target now runs inside a pinned Docker image to ensure a consistent `clang-format` version across contributors and CI. ([#3472](https://github.com/open-telemetry/opentelemetry-go-instrumentation/pull/3472))
+
 ### Removed
 
 - Build support for [Go 1.23] has been removed.

--- a/Makefile
+++ b/Makefile
@@ -304,10 +304,11 @@ MARKDOWNIMAGE := $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKER
 markdown-lint:
 	docker run --rm -u $(DOCKER_USER) -v "$(CURDIR):$(WORKDIR)" $(MARKDOWNIMAGE) -c $(WORKDIR)/.markdownlint.yaml -p $(WORKDIR)/.markdownlintignore $(WORKDIR)/**/*.md
 
+CLANGFORMATIMAGE := $(shell awk '$$4=="clang-format" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 .PHONY: clang-format
 clang-format:
-	find ./internal -type f -name "*.c" | xargs -P 0 -n 1 clang-format -i
-	find ./internal -type f -name "*.h" | xargs -P 0 -n 1 clang-format -i
+	docker run --rm -u $(DOCKER_USER) -v "$(CURDIR):$(WORKDIR)" -w $(WORKDIR) $(CLANGFORMATIMAGE) \
+		sh -c 'find ./internal -type f \( -name "*.c" -o -name "*.h" \) | xargs -P 0 -n 1 clang-format -i'
 
 .PHONY: install-hooks
 install-hooks:

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -1,3 +1,4 @@
 # This is a renovate-friendly source of Docker images.
 FROM avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee AS markdown
 FROM python:3.13.6-slim-bullseye@sha256:e98b521460ee75bca92175c16247bdf7275637a8faaeb2bcfa19d879ae5c4b9a AS python
+FROM xianpengshen/clang-tools:19@sha256:08ceb9f83b59e431d5ac2d008ca7e5c876dd486c18387cb7af42e520a688e3ab AS clang-format

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-# Format all staged C/C++ files
+# Format all staged C/C++ files using the clang-format docker image pinned in
+# dependencies.Dockerfile so the version stays consistent with the
+# `make clang-format` target and the clang-format CI workflow.
 files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|cpp|h)$')
 
 if [ -n "$files" ]; then
     echo "Running clang-format on:"
     echo "$files"
 
-    # Run clang-format on the staged files
+    repo_root=$(git rev-parse --show-toplevel)
+    image=$(awk '$4=="clang-format" {print $2}' "$repo_root/dependencies.Dockerfile")
+
+    # Run clang-format on all staged files in a single container invocation.
+    docker run --rm -u "$(id -u):$(id -g)" -v "$repo_root:/workdir" -w /workdir "$image" \
+        clang-format -i $files
+
+    # Re-add formatted files to staging.
     for file in $files; do
-        clang-format -i "$file"
-        git add "$file"  # Re-add formatted files to staging
+        git add "$file"
     done
 fi


### PR DESCRIPTION
Update the Makefile clang-format target to invoke clang-format inside a Docker image pinned in dependencies.Dockerfile
Resolves #2774