### PR TITLE
process: reduce pointer usage in Info to lower GC pressure

### DIFF
--- a/internal/pkg/instrumentation/bpffs/bpfsfs_other.go
+++ b/internal/pkg/instrumentation/bpffs/bpfsfs_other.go
@@ -9,14 +9,14 @@ import "go.opentelemetry.io/auto/internal/pkg/process"
 
 // Stubs for non-linux systems
 
-func PathForTargetApplication(target *process.TargetDetails) string {
+func PathForTargetApplication(target *process.Info) string {
 	return ""
 }
 
-func Mount(target *process.TargetDetails) error {
+func Mount(target *process.Info) error {
 	return nil
 }
 
-func Cleanup(target *process.TargetDetails) error {
+func Cleanup(target *process.Info) error {
 	return nil
 }

--- a/internal/pkg/instrumentation/kernel/cpu_other.go
+++ b/internal/pkg/instrumentation/kernel/cpu_other.go
@@ -5,4 +5,4 @@
 
 package kernel
 
-func cpuCount() (int, error) { return 0, nil }
+func cpuCount() (uint64, error) { return 0, nil }

--- a/internal/pkg/instrumentation/probe/probe.go
+++ b/internal/pkg/instrumentation/probe/probe.go
@@ -182,7 +182,8 @@ func (i *Base[BPFObj, BPFEvent]) loadUprobes(exec *link.Executable, info *proces
 	for _, up := range i.Uprobes {
 		var skip bool
 		for _, pc := range up.PackageConstraints {
-			if pc.Constraints.Check(info.Modules[pc.Package]) {
+			pkgVer := info.Modules[pc.Package]
+			if pc.Constraints.Check(&pkgVer) {
 				continue
 			}
 
@@ -527,7 +528,7 @@ func (c StructFieldConst) InjectOption(info *process.Info) (inject.Option, error
 		return nil, fmt.Errorf("unknown module: %s", c.ID.ModPath)
 	}
 
-	off, ok := inject.GetOffset(c.ID, ver)
+	off, ok := inject.GetOffset(c.ID, &ver)
 	if !ok || !off.Valid {
 		if c.logger != nil {
 			c.logger.Info(

--- a/internal/pkg/process/binary/funcs_nonstripped.go
+++ b/internal/pkg/process/binary/funcs_nonstripped.go
@@ -13,13 +13,13 @@ import (
 func FindFunctionsUnStripped(
 	elfF *elf.File,
 	relevantFuncs map[string]any,
-) ([]*Func, error) {
+) ([]Func, error) {
 	symbols, err := elfF.Symbols()
 	if err != nil {
 		return nil, err
 	}
 
-	var result []*Func
+	var result []Func
 	for _, f := range symbols {
 		_, exists := relevantFuncs[f.Name]
 		if !exists {
@@ -35,13 +35,11 @@ func FindFunctionsUnStripped(
 			return nil, err
 		}
 
-		function := &Func{
+		result = append(result, Func{
 			Name:          f.Name,
 			Offset:        offset,
 			ReturnOffsets: returns,
-		}
-
-		result = append(result, function)
+		})
 	}
 
 	return result, nil

--- a/internal/pkg/process/binary/funcs_stripped.go
+++ b/internal/pkg/process/binary/funcs_stripped.go
@@ -12,7 +12,7 @@ import (
 	"math"
 )
 
-func FindFunctionsStripped(elfF *elf.File, relevantFuncs map[string]any) ([]*Func, error) {
+func FindFunctionsStripped(elfF *elf.File, relevantFuncs map[string]any) ([]Func, error) {
 	var sec *elf.Section
 	if sec = elfF.Section(".gopclntab"); sec == nil {
 		return nil, fmt.Errorf("%s section not found in target binary", ".gopclntab")
@@ -51,7 +51,7 @@ func FindFunctionsStripped(elfF *elf.File, relevantFuncs map[string]any) ([]*Fun
 		return nil, err
 	}
 
-	var result []*Func
+	var result []Func
 	for _, f := range symTab.Funcs {
 		if _, exists := relevantFuncs[f.Name]; exists {
 			start, returns, err := findFuncOffsetStripped(&f, elfF)
@@ -59,13 +59,11 @@ func FindFunctionsStripped(elfF *elf.File, relevantFuncs map[string]any) ([]*Fun
 				return nil, err
 			}
 
-			function := &Func{
+			result = append(result, Func{
 				Name:          f.Name,
 				Offset:        start,
 				ReturnOffsets: returns,
-			}
-
-			result = append(result, function)
+			})
 		}
 	}
 

--- a/internal/pkg/process/info.go
+++ b/internal/pkg/process/info.go
@@ -22,14 +22,14 @@ import (
 // Info are the details about a target process.
 type Info struct {
 	ID        ID
-	Functions []*binary.Func
+	Functions []binary.Func
 	// GoVersion is the semantic version of Go run by the target process.
 	//
 	// Experimental and build information included in the version is dropped.
 	// If a development version of Go is used, the commit hash will be included
 	// in the metadata of the version.
-	GoVersion *semver.Version
-	Modules   map[string]*semver.Version
+	GoVersion semver.Version
+	Modules   map[string]semver.Version
 
 	aDone atomic.Bool
 	aMu   sync.Mutex
@@ -89,10 +89,11 @@ func NewInfo(id ID, relevantFuncs map[string]any) (*Info, error) {
 		return nil, err
 	}
 
-	result.GoVersion, err = goVer(bi.GoVersion)
+	gv, err := goVer(bi.GoVersion)
 	if err != nil {
 		return nil, err
 	}
+	result.GoVersion = *gv
 
 	result.Functions, err = findFunctions(elfF, relevantFuncs)
 	if err != nil {
@@ -143,11 +144,11 @@ const develModVer = "(devel)"
 
 // VerDevel is the placeholder version used for modules that use the
 // development version "(devel)".
-var VerDevel = semver.MustParse("0.0.0-dev")
+var VerDevel = *semver.MustParse("0.0.0-dev")
 
-func findModules(goVer *semver.Version, deps []*debug.Module) (map[string]*semver.Version, error) {
+func findModules(goVer semver.Version, deps []*debug.Module) (map[string]semver.Version, error) {
 	var err error
-	out := make(map[string]*semver.Version, len(deps)+1)
+	out := make(map[string]semver.Version, len(deps)+1)
 	for _, dep := range deps {
 		if dep.Version == develModVer {
 			// dep.Version is not a parsable semantic version. Do not error.
@@ -164,13 +165,13 @@ func findModules(goVer *semver.Version, deps []*debug.Module) (map[string]*semve
 			)
 			continue
 		}
-		out[dep.Path] = depVersion
+		out[dep.Path] = *depVersion
 	}
 	out["std"] = goVer
 	return out, err
 }
 
-func findFunctions(elfF *elf.File, relevantFuncs map[string]any) ([]*binary.Func, error) {
+func findFunctions(elfF *elf.File, relevantFuncs map[string]any) ([]binary.Func, error) {
 	found, err := binary.FindFunctionsUnStripped(elfF, relevantFuncs)
 	if err != nil {
 		if !errors.Is(err, elf.ErrNoSymbols) {


### PR DESCRIPTION
## Summary

Replaces pointer-heavy fields in `process.Info` with value types to reduce heap object count and GC scan work for large instrumented binaries.

**Changes to `Info`:**
| Field | Before | After |
|-------|--------|-------|
| `Functions` | `[]*binary.Func` | `[]binary.Func` |
| `GoVersion` | `*semver.Version` | `semver.Version` |
| `Modules` | `map[string]*semver.Version` | `map[string]semver.Version` |

Also fixes two non-Linux build stub mismatches found during this work:

- `bpffs_other.go`: stale `TargetDetails` type reference → `Info`
- `cpu_other.go`: `cpuCount()` returned `int` instead of `uint64`