### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 [![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/auto)](https://pkg.go.dev/go.opentelemetry.io/auto)
 
-This repository provides [OpenTelemetry] tracing instrumentation for [Go] libraries using [eBPF].
+> [!WARNING]
+> **This project is deprecated**
+>
+> **OpenTelemetry Go Automatic Instrumentation is no longer actively maintained.**
+> End users and vendors should migrate to [OpenTelemetry eBPF Instrumentation (OBI)](https://opentelemetry.io/docs/zero-code/obi), the upstream OpenTelemetry project for zero-code, eBPF-based application observability.
+>
+> **Migrate to OBI**
+>
+> - [Documentation](https://opentelemetry.io/docs/zero-code/obi)
+> - [GitHub repository](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation)
+> - [CNCF Slack `#otel-ebpf-instrumentation`](https://cloud-native.slack.com/archives/C06DQ7S2YEP) ([join CNCF Slack](https://slack.cncf.io))
+>
+> If you are migrating from this project, we encourage you to share feedback, opinions, and feature gaps in the OBI [GitHub Discussions](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/discussions) or on Slack so they can inform the OBI roadmap.
+> Due to limited maintainer bandwidth, there are **no official plans to provide zero-change migrations** from this project to OBI,
+> but any contributions toward this goal are welcome.
 
-:construction: This project is currently work in progress.
+This repository provides [OpenTelemetry] tracing instrumentation for [Go] libraries using [eBPF].
 
 ## Compatibility
 


### PR DESCRIPTION
As discussed in the SIG meeting on [6/4/2026](google.com/url?q=https://docs.google.com/document/d/1P6am_r_cxCX1HcpDQlznrTrTOvwN2whshL0f58lXSWI/edit?usp%3Dsharing&sa=D&source=calendar&ust=1782822782137318&usg=AOvVaw36IpV9f9uG9FUmIOMXaarn), this project has entered a sunset mode where we plan to migrate maintainer effort and community focus toward OBI.

This adds a notice to the readme and encourages any contributions toward the migration, but as discussed it makes no guarantees for migration to be considered in the current OBI roadmap.