### PR TITLE
build: Switch to Markdownlint-cli2

### DIFF
--- a/.github/workflows/markdown-fail-fast.yml
+++ b/.github/workflows/markdown-fail-fast.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Run linter
-      uses: docker://avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee
+      uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
       with:
-        args: ${{needs.changedfiles.outputs.md}}
+        config: .markdownlint-cli2.yaml
+        fix: false
+        globs: |
+          ${{needs.changedfiles.outputs.md}}

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -19,16 +19,29 @@ jobs:
 
     - name: Run linter
       id: markdownlint
-      uses: docker://avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee
+      uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
       with:
-        config: .markdownlint.yaml
-        args: '**/*.md'
-        output: ./markdownlint.txt
+        config: .markdownlint-cli2.yaml
+        fix: false
+        globs: |
+          '**/*.md'
+      continue-on-error: true
 
-    - name: Create Issue From File
-      if: steps.markdownlint.outputs.exit_code != 0
-      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
-      with:
-        title: Markdown Lint Report
-        content-filepath: ./markdownlint.txt
-        labels: report, bot-generated
+    - name: Manage issue
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        number=$(gh issue list --search "in:title Workflow failed: $GITHUB_WORKFLOW" --limit 1 --json number -q .[].number)
+
+        echo $number
+        echo ${{ inputs.success }}
+
+        if [[ $number ]]; then
+          if [[ "${{ steps.markdownlint.outcome }}" != "failure" ]]; then
+            gh issue close $number
+          fi
+        elif [[ "${{ steps.markdownlint.outcome }}" == "failure"  ]]; then
+          gh issue create --title "Workflow failed: $GITHUB_WORKFLOW (#$GITHUB_RUN_NUMBER)" \
+                          --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." \
+                          --label "report,bot-generated"
+        fi

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,3 @@
+config:
+  extends: .markdownlint.yaml
+gitignore: '**/.{git,markdownlint}ignore'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -27,3 +27,5 @@ MD033: false
 # fenced-code-language
 MD040: false
 
+# table-column-style
+MD060: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 LICENSES
 venv
+.github/ISSUE_TEMPLATE

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ codespell: $(CODESPELL)
 MARKDOWNIMAGE := $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 .PHONY: markdown-lint
 markdown-lint:
-	docker run --rm -u $(DOCKER_USER) -v "$(CURDIR):$(WORKDIR)" $(MARKDOWNIMAGE) -c $(WORKDIR)/.markdownlint.yaml -p $(WORKDIR)/.markdownlintignore $(WORKDIR)/**/*.md
+	docker run --rm -u $(DOCKER_USER) -v "$(CURDIR):$(WORKDIR)" $(MARKDOWNIMAGE) --config $(WORKDIR)/.markdownlint-cli2.yaml $(WORKDIR)/**/*.md
 
 .PHONY: clang-format
 clang-format:

--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -1,3 +1,3 @@
 # This is a renovate-friendly source of Docker images.
-FROM avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee AS markdown
+FROM davidanson/markdownlint-cli2:v0.23.1@sha256:f382ea4fdc949883e79de678009437fb40c339323654c7b0dd4d5221cda8ed20 AS markdown
 FROM python:3.13.6-slim-bullseye@sha256:e98b521460ee75bca92175c16247bdf7275637a8faaeb2bcfa19d879ae5c4b9a AS python


### PR DESCRIPTION
Switch to a mantained markdownlint docker image/gh-action.

Note the new violation has been suppressed.

The scheduled check has been changed to mirror semconv and provide link to the action. This approach enables the github annotations to be visible hence improving usability etc.