### PR TITLE
docs: add Nomad getting started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 You can instrument a Go executable using OpenTelemetry without writing additional code.
 All you need to do is configure a few environment variables and run the instrumentation with elevated privileges.
 
-This guide demonstrates how to automatically instrument a Go application in Kubernetes, using Docker, and on a Linux host.
+This guide demonstrates how to automatically instrument a Go application in Kubernetes, Docker Compose, HashiCorp Nomad, and directly on a Linux host.
 
 ## Instrument an Application in Kubernetes
 
@@ -71,6 +71,71 @@ To instrument a containerized application, follow these steps:
    ```sh
    docker compose up
    ```
+
+## Instrument an Application in HashiCorp Nomad
+
+To instrument an application running in HashiCorp Nomad, deploy the auto-instrumentation container as a sidecar task in the same task group.
+Ensure the instrumentation container has access to the executable specified by `OTEL_GO_AUTO_TARGET_EXE`.
+
+Example:
+
+```hcl
+job "<job_name>" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "<task_group_name>" {
+    count = 1
+
+    task "autoinstrumentation-go" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = true
+      }
+
+      env {
+        OTEL_GO_AUTO_TARGET_EXE     = "<path_to_target_executable>"
+        OTEL_SERVICE_NAME           = "<service_name>"
+        OTEL_EXPORTER_OTLP_ENDPOINT = "http://<collector_address>:4318"
+        OTEL_PROPAGATORS            = "tracecontext,baggage"
+      }
+
+      config {
+        image      = "otel/autoinstrumentation-go:<version>"
+        privileged = true
+        pid_mode   = "host"
+        volumes = [
+          "/proc:/host/proc:ro",
+        ]
+      }
+    }
+
+    task "<application_task_name>" {
+      driver = "docker"
+
+      config {
+        image = "<application_image>"
+      }
+    }
+  }
+}
+```
+
+Configure the instrumentation task as a prestart sidecar so it is running before the application starts.
+This example uses Docker host PID mode because the instrumentation container must be able to discover the target process running in the application container.
+Mount the host `/proc` filesystem so the instrumentation container can discover and attach to the target process.
+The instrumentation container must run with `privileged = true` to attach to the target process.
+The instrumentation task attaches to the target Go application and exports telemetry to the configured OpenTelemetry Collector.
+
+Validate the setup by sending traffic to the application:
+
+```sh
+curl http://<application_address>/hello
+```
+
+Then verify that telemetry is exported to your configured OpenTelemetry backend.
 
 ## Instrument an Application on the Same Host
 


### PR DESCRIPTION
## Summary

Add a Nomad section to the Getting Started guide with an example job specification for deploying OpenTelemetry Go Automatic Instrumentation as a sidecar task.

The guide covers:
- Required task configuration
- Environment variables
- Process visibility requirements
- Basic verification steps

## Testing

- Reviewed Markdown formatting
- Ran `git diff --check`

## Notes

This is a documentation-only change.