### PR TITLE
fix: use replace directive version when detecting module versions(#3855)

### DIFF
--- a/internal/pkg/process/info.go
+++ b/internal/pkg/process/info.go
@@ -149,18 +149,30 @@ func findModules(goVer *semver.Version, deps []*debug.Module) (map[string]*semve
 	var err error
 	out := make(map[string]*semver.Version, len(deps)+1)
 	for _, dep := range deps {
-		if dep.Version == develModVer {
-			// dep.Version is not a parsable semantic version. Do not error.
+		// A replace directive swaps in different code than the required
+		// version. The required version remains in dep.Version while the
+		// replacement is kept in dep.Replace, and the replacement is what
+		// is actually linked into the binary. Prefer its version so probes
+		// match the code that is really running. Directory replacements
+		// carry no usable version ("(devel)" or empty) and fall back to the
+		// required version.
+		ver := dep.Version
+		if r := dep.Replace; r != nil && r.Version != "" && r.Version != develModVer {
+			ver = r.Version
+		}
+
+		if ver == develModVer {
+			// ver is not a parsable semantic version. Do not error.
 			// Instead, use VerDevel to signal this development version state.
 			out[dep.Path] = VerDevel
 			continue
 		}
 
-		depVersion, e := semver.NewVersion(dep.Version)
+		depVersion, e := semver.NewVersion(ver)
 		if e != nil {
 			err = errors.Join(
 				err,
-				fmt.Errorf("invalid dependency version %s (%s): %w", dep.Path, dep.Version, e),
+				fmt.Errorf("invalid dependency version %s (%s): %w", dep.Path, ver, e),
 			)
 			continue
 		}

--- a/internal/pkg/process/info_test.go
+++ b/internal/pkg/process/info_test.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"testing"
 
@@ -12,6 +13,50 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFindModules(t *testing.T) {
+	deps := []*debug.Module{
+		{
+			Path: "google.golang.org/grpc",
+			// The linked code comes from a replace directive; probes need
+			// the replacement version, not the required one.
+			Version: "v1.82.1",
+			Replace: &debug.Module{
+				Path:    "google.golang.org/grpc",
+				Version: "v1.65.0",
+			},
+		},
+		{
+			Path:    "example.com/fork",
+			Version: "v1.0.0",
+			Replace: &debug.Module{
+				Path:    "github.com/example/fork",
+				Version: "v1.1.0",
+			},
+		},
+		{
+			// Directory replacements have no version; keep the required one.
+			Path:    "example.com/dir",
+			Version: "v1.2.3",
+			Replace: &debug.Module{
+				Path:    "/local/dir",
+				Version: "(devel)",
+			},
+		},
+		{Path: "example.com/normal", Version: "v2.0.0"},
+		{Path: "example.com/devel", Version: "(devel)"},
+	}
+
+	m, err := findModules(semver.MustParse("1.26.4"), deps)
+	require.NoError(t, err)
+
+	assert.Equal(t, semver.MustParse("v1.65.0"), m["google.golang.org/grpc"])
+	assert.Equal(t, semver.MustParse("v1.1.0"), m["example.com/fork"])
+	assert.Equal(t, semver.MustParse("v1.2.3"), m["example.com/dir"])
+	assert.Equal(t, semver.MustParse("v2.0.0"), m["example.com/normal"])
+	assert.Equal(t, VerDevel, m["example.com/devel"])
+	assert.Equal(t, semver.MustParse("1.26.4"), m["std"])
+}
 
 func TestGoVer(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes #3855
## Problem
Module version detection of the target process (`findModules` in
`internal/pkg/process/info.go`) reads only `debug.Module.Version`, which reflects
the `require` directive. When a binary is built with a `replace` directive, the
code actually linked into the binary comes from the *replacement*, whose version
buildinfo records in `Module.Replace.Version`
(https://pkg.go.dev/runtime/debug#Module). Probes therefore select uprobe
variants and struct offset lookups for a version that is not actually running.
Consequences:
- **Hard failure** when the required and replaced versions cross a probe version
  boundary. Example: with
  ```
  require google.golang.org/grpc v1.82.1
  replace google.golang.org/grpc => google.golang.org/grpc v1.65.0
  ```
  the target really contains pre-1.69 code (grpc v1.69.0 introduced
  `transport.ServerStream` and renamed `WriteStatus` to unexported
  `writeStatus`), but `process.Modules` reports `1.82.1`. The gRPC server probe
  then requires the `ServerStream:Stream` offset and aborts:
  ```
  failed to find offset for "google.golang.org/grpc/internal/transport.ServerStream:Stream":
  struct "google.golang.org/grpc/internal/transport.ServerStream" not found
  ```
  The CLI exits, so sidecar containers crash-loop.
- **Silent wrong offsets** when no boundary is crossed — struct layouts differ
  across versions (`transport.Stream:method` is 16 on v1.82.1 but 88 on v1.65.0),
  so wrong cached offsets are injected.
## Solution
Prefer `dep.Replace.Version` when the replacement carries a usable semantic
version:
```go
ver := dep.Version
if r := dep.Replace; r != nil && r.Version != "" && r.Version != "(devel)" {
    ver = r.Version
}
```
Directory replacements (`replace ... => ../local`) carry `(devel)` and fall back
to the required version, preserving existing behavior. Dependencies without a
`replace` are unaffected.
## Testing
- [x] Unit test `TestFindModules` covering: version replace, replace to a
      different path with version, directory replace (`(devel)`), plain
      dependency, `(devel)` dependency, and the `std` entry.
- [x] Manual e2e with a binary built from the `go.mod` above: before the fix
      `loaded process info` reported `grpc: 1.82.1` and the gRPC server probe
      failed with `ServerStream ... not found`; after the fix it reports
      `grpc: 1.65.0` and loads the pre-1.69 uprobe variants from cache.